### PR TITLE
Possible PMCMC fix.

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -1033,6 +1033,7 @@ function PMCMC(cc, a, wpplFn, numParticles, numSweeps){
   this.address = a;
   this.numParticles = numParticles;
   this.resetParticles();
+  this.returnHist = {};
 
   // Run first particle
   this.activeContinuation()();
@@ -1144,13 +1145,24 @@ PMCMC.prototype.exit = function(retval) {
 
   } else {
 
-    if (this.sweep < this.numSweeps) {
+    // Use all (unweighted) particles from the conditional SMC
+    // iteration to estimate marginal distribution.
+    if (this.sweep > 0) {
+      _.each(
+        this.particles.concat(this.retainedParticle),
+        function(particle){
+          var k = JSON.stringify(particle.value);
+          if (coroutine.returnHist[k] === undefined){
+            coroutine.returnHist[k] = { prob:0, val:particle.value };
+          }
+          coroutine.returnHist[k].prob += 1;
+        });
+    };
 
-      // Resample retained particle based on total path weight
-      var weights = this.particles.map(
-        function(particle){return Math.exp(util.sum(particle.weights));});
-      var j = multinomialSample(weights);
-      this.retainedParticle = this.particles[j];
+    // Retain the first particle sampled after the final factor statement.
+    this.retainedParticle = this.particles[0];
+
+    if (this.sweep < this.numSweeps) {
 
       // Reset non-retained particles, restart
       this.sweep += 1;
@@ -1159,20 +1171,7 @@ PMCMC.prototype.exit = function(retval) {
       this.activeContinuation()();
 
     } else {
-
-      // Compute marginal distribution from (unweighted) particles
-      var hist = {};
-      _.each(
-        this.particles,
-        function(particle){
-          var k = JSON.stringify(particle.value);
-          if (hist[k] === undefined){
-            hist[k] = { prob:0, val:particle.value };
-          }
-          hist[k].prob += 1;
-        });
-
-      var dist = makeMarginalERP(hist);
+      var dist = makeMarginalERP(this.returnHist);
 
       // Reinstate previous coroutine:
       coroutine = this.oldCoroutine;


### PR DESCRIPTION
Hi.

Thanks for publishing dippl, I've had great fun working through it and I learning a _lot_.

I've been playing with the PMCMC implementation in webppl and assuming it's doing particle Gibbs I'm not sure it's correct.

(Before I go on, I should point out that I'm not all that familiar with PMCMC, so please keep in mind the possibility that I'm entirely mistaken about what's happening here.)

This commit makes two changes, I think they fix the correctness issue.

1) The particles from every iteration of conditional SMC are now used in the estimate of the marginal. Previously only the particles from the last iteration were used.

2) The first non-retained particle is now deterministically chosen as the retained particle for the next iteration. The reason I think this is correct is that the retained particle should be a sample from the set of weighted particles we have after the last factor statement. Since this final set is re-sampled (with weights) before the exit function is reached, once in the exit function all of the particles are independent draws from the distribution from which the retained particle should be drawn. Any of them could be used, the first is easiest.

I've tried this out on a few examples and it seems to do the right thing, though I'm still unsure. What do you think?
