### PR TITLE
more efficient MH

### DIFF
--- a/src/inference/mh.js
+++ b/src/inference/mh.js
@@ -9,125 +9,157 @@ var erp = require('../erp.js');
 
 module.exports = function(env) {
 
-  function findChoice(trace, name) {
-    if (trace === undefined) {
-      return undefined;
-    }
-    for (var i = 0; i < trace.length; i++) {
-      if (trace[i].name === name) {
-        return trace[i];
-      }
-    }
-    return undefined;
+  function makeTraceEntry(s, k, name, erp, params, currScore, choiceScore, val, reuse) {
+    return {k: k, name: name, erp: erp, params: params, score: currScore,
+      choiceScore: choiceScore, val: val, reused: reuse, store: s};
   }
 
-  function acceptProb(trace, oldTrace, regenFrom, currScore, oldScore) {
-    if ((oldTrace === undefined) || oldScore === -Infinity) {
-      return 1;
-    } // init
-    var fw = -Math.log(oldTrace.length);
-    trace.slice(regenFrom).map(function(s) {
-      fw += s.reused ? 0 : s.choiceScore;
+  var deepCopyTrace = function(trace) {
+    return trace.map(function(obj) {
+      var objCopy = _.clone(obj);
+      objCopy.store = _.clone(obj.store);
+      return objCopy;
     });
-    var bw = -Math.log(trace.length);
-    oldTrace.slice(regenFrom).map(function(s) {
-      var nc = findChoice(trace, s.name);
-      bw += (!nc || !nc.reused) ? s.choiceScore : 0;
-    });
+  };
+
+  function acceptProb(currScore, oldScore, traceLength, oldTraceLength, bwdLP, fwdLP) {
+    if (oldScore === -Infinity || oldTraceLength === 0) return 1; // initialize phase
+    if (currScore === -Infinity) return 0; // early exit
+    var fw = fwdLP - Math.log(oldTraceLength);
+    var bw = bwdLP - Math.log(traceLength);
     var p = Math.exp(currScore - oldScore + bw - fw);
     assert.ok(!isNaN(p));
-    var acceptance = Math.min(1, p);
-    return acceptance;
+    return Math.min(1, p);
+  }
+
+  function sampler(s, k, name, erp, params, forceSample) {
+    var prev = this.sites[name];
+    var reuse = !(prev === undefined || forceSample);
+    var val = reuse ? prev.val : erp.sample(params);
+    if (forceSample && prev && prev.val === val) { // exit early if proposed and no change
+      this.sites = this.oldSites;
+      this.trace = this.oldTrace;
+      this.currScore = this.oldScore;
+      return this.exit(s, this.oldVal);
+    } else {
+      var choiceScore = erp.score(params, val);
+      var newEntry = makeTraceEntry(_.clone(s), k, name, erp, params,
+                                    this.currScore, choiceScore, val, reuse)
+      this.sites[name] = newEntry;
+      this.currScore += choiceScore;
+      this.trace.push(newEntry);
+      if (prev === undefined) { // creating new choice
+        this.fwdLP += choiceScore;
+      } else if (forceSample) { // made a proposal to this choice
+        this.fwdLP += choiceScore;
+        this.bwdLP += prev.choiceScore;
+      }
+      return (choiceScore === -Infinity) ? this.exit(s) : k(s, val); // possible early exit
+    }
+  }
+
+  function proposer(val, cloner) {
+    this.regenFrom = Math.floor(Math.random() * this.trace.length);
+    var regen = this.trace[this.regenFrom];
+    this.oldSites = this.sites;
+    this.sites = _.clone(this.sites);
+    this.oldTrace = cloner === undefined ? this.trace : cloner(this.trace);
+    this.trace = this.oldTrace.slice(0, this.regenFrom);
+    this.fwdLP = 0;
+    this.bwdLP = 0;
+    this.oldScore = this.currScore;
+    this.currScore = regen.score;
+    this.oldVal = val;
+    return this.sample(_.clone(regen.store), regen.k, regen.name, regen.erp, regen.params, true);
   }
 
   function MH(s, k, a, wpplFn, numIterations) {
-
-    this.trace = [];
-    this.oldTrace = undefined;
-    this.currScore = 0;
-    this.oldScore = -Infinity;
-    this.oldVal = undefined;
-    this.regenFrom = 0;
-    this.returnHist = {};
-    this.k = k;
-    this.oldStore = s;
     this.iterations = numIterations;
-
-    // Move old coroutine out of the way and install this as the current
-    // handler.
+    this.totalIterations = numIterations;
+    this.hist = {};
+    this.numAccepted = 0;
+    this.regenFrom = 0;
 
     this.wpplFn = wpplFn;
-    this.s = s;
+    this.k = k;
+    this.oldStore = s;
     this.a = a;
 
+    // Move old coroutine out of the way and install this as current handler.
     this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
   MH.prototype.run = function() {
+    this.sites = {};
+    this.trace = [];
+    this.s = _.clone(this.oldStore);
+    this.currScore = 0;
+    this.oldScore = -Infinity;
+    this.fwdLP = 0;
+    this.bwdLP = 0;
     return this.wpplFn(this.s, env.exit, this.a);
   };
 
   MH.prototype.factor = function(s, k, a, score) {
     this.currScore += score;
-    return k(s);
+    return this.currScore === -Infinity ? this.exit(s) : k(s); // possible early exit
   };
 
-  MH.prototype.sample = function(s, cont, name, erp, params, forceSample) {
-    var prev = findChoice(this.oldTrace, name);
+  MH.prototype.sample = function() {
+    return sampler.apply(this, arguments);
+  };
 
-    var reuse = !(prev === undefined || forceSample);
-    var val = reuse ? prev.val : erp.sample(params);
-    var choiceScore = erp.score(params, val);
-    this.trace.push({
-      k: cont, name: name, erp: erp, params: params,
-      score: this.currScore, choiceScore: choiceScore,
-      val: val, reused: reuse, store: _.clone(s)
-    });
-    this.currScore += choiceScore;
-    return cont(s, val);
+  MH.prototype.propose = function() {
+    return proposer.apply(this, arguments);
   };
 
   MH.prototype.exit = function(s, val) {
     if (this.iterations > 0) {
+      if (this.iterations === this.totalIterations && this.currScore === -Infinity)
+        return this.run();      // when uninitialized and failing, do rejection-sampling
       this.iterations -= 1;
-
-      //did we like this proposal?
-      var acceptance = acceptProb(this.trace, this.oldTrace,
-          this.regenFrom, this.currScore, this.oldScore);
+      // housekeeping - remove dead refs and recompute backward logprob
+      if (this.oldTrace !== undefined && this.currScore !== -Infinity) {
+        var i, reached = {};
+        for (i = this.regenFrom; i < this.trace.length; i++)
+          reached[this.trace[i].name] = this.trace[i];
+        for (i = this.regenFrom; i < this.oldTrace.length; i++) {
+          var v = this.oldTrace[i];
+          if (reached[v.name] === undefined) {
+            delete this.sites[v.name];
+            this.bwdLP += v.choiceScore;
+          }
+        }
+      }
+      // did we like this proposal?
+      var acceptance = acceptProb(this.currScore,
+                                  this.oldScore,
+                                  this.trace.length,
+                                  this.oldTrace === undefined ? 0 : this.oldTrace.length,
+                                  this.bwdLP,
+                                  this.fwdLP);
+      // if rejected, roll back trace, etc:
       if (Math.random() >= acceptance) {
-        // if rejected, roll back trace, etc:
+        this.sites = this.oldSites;
         this.trace = this.oldTrace;
         this.currScore = this.oldScore;
         val = this.oldVal;
+      } else {
+        this.numAccepted++;
       }
-
       // now add val to hist:
-      var stringifiedVal = JSON.stringify(val);
-      if (this.returnHist[stringifiedVal] === undefined) {
-        this.returnHist[stringifiedVal] = {prob: 0, val: val};
-      }
-      this.returnHist[stringifiedVal].prob += 1;
-
-      // make a new proposal:
-      this.regenFrom = Math.floor(Math.random() * this.trace.length);
-      var regen = this.trace[this.regenFrom];
-      this.oldTrace = this.trace;
-      this.trace = this.trace.slice(0, this.regenFrom);
-      this.oldScore = this.currScore;
-      this.currScore = regen.score;
-      this.oldVal = val;
-
-      return this.sample(_.clone(regen.store), regen.k, regen.name, regen.erp, regen.params, true);
+      var l = JSON.stringify(val);
+      if (this.hist[l] === undefined) this.hist[l] = {prob: 0, val: val};
+      this.hist[l].prob += 1;
+      // make a new proposal
+      return this.propose(val);
     } else {
-      var dist = erp.makeMarginalERP(this.returnHist);
-
-      // Reinstate previous coroutine:
+      var dist = erp.makeMarginalERP(this.hist);
+      dist.acceptanceRatio = this.numAccepted / this.totalIterations;
       var k = this.k;
-      env.coroutine = this.oldCoroutine;
-
-      // Return by calling original continuation:
-      return k(this.oldStore, dist);
+      env.coroutine = this.oldCoroutine; // Reinstate previous coroutine
+      return k(this.oldStore, dist); // Return by calling original continuation
     }
   };
 
@@ -137,7 +169,10 @@ module.exports = function(env) {
 
   return {
     MH: mh,
-    findChoice: findChoice,
+    makeTraceEntry: makeTraceEntry,
+    deepCopyTrace: deepCopyTrace,
+    sampler: sampler,
+    proposer: proposer,
     acceptProb: acceptProb
   };
 


### PR DESCRIPTION
 - use hashmap for efficiency (similar to DanR's version)
 - other assorted minor efficiencies
 - modularize so reuse is better (in future branches/commits to merge into dev)
   [deepcopytrace moved into MH to faciliate exports to other places where mh may be used]

 Changes to smc.js are superficial and were needed to make tests work because of
 dependence on old MH stuff. Once this is merged, smc can be updated to use new MH
 and pf with var#factors.