### PR TITLE
HashMH Store Handling Fix

### DIFF
--- a/src/inference/hashmh.js
+++ b/src/inference/hashmh.js
@@ -68,7 +68,7 @@ module.exports = function(env) {
     this.oldScore = -Infinity;
     this.query = new Query();
     env.query.clear();
-    return this.wpplFn(this.s, env.exit, this.a);
+    return this.wpplFn(_.clone(this.s), env.exit, this.a);
   };
 
   HashMH.prototype.factor = function(s, k, a, score) {


### PR DESCRIPTION
HashMH uses something like rejection sampling to find an initial trace with a non-zero probability. The store isn't reset across these executions leading to incorrect results.

I discovered this when I added store handling inference tests for HashMH as part of #94.

This change fixes the problem and doesn't appear to break things.