### PR TITLE
Enable debugger statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,13 @@ To debug WebPPL programs running in Chrome, enable [pause on JavaScript exceptio
 
     // 1. Install node-inspector (only need to do this once)
     npm install -g node-inspector
-    
-    // 2. Compile your webppl program to Javascript
-    webppl my-program.wppl --compile --out my-program.js
-    
-    // 3. Add "debugger;" statements to my-program.js to indicate breakpoints
-    
-    // 4. Run your compiled program in debug mode (will pause automatically)
-    node --debug-brk my-program.js
-    
-    // 5. (In separate terminal:) Load node inspector, resume program execution in node-inspector
+
+    // 2. Add "debugger;" statements to my-program.js to indicate breakpoints
+
+    // 3. Run your compiled program in debug mode (will pause automatically)
+    node --debug-brk webppl my-program.js
+
+    // 4. (In separate terminal:) Load node inspector, resume program execution in node-inspector
     node-inspector
 
 

--- a/src/transforms/cps.js
+++ b/src/transforms/cps.js
@@ -139,8 +139,11 @@ function atomize(node, metaK) {
       return atomize(argument, function(argument) {
         return metaK(build.unaryExpression(node.operator, argument));
       });
+    }),
+    clause(Syntax.DebuggerStatement, function() {
+      var body = build.blockStatement([node]);
+      return metaK(buildCall(build.functionExpression(null, [], body), []));
     })
-
 
   ], fail('atomize: unrecognized node', node));
 }
@@ -174,6 +177,7 @@ function cps(node, k) {
     case Syntax.MemberExpression:
     case Syntax.ObjectExpression:
     case Syntax.UnaryExpression:
+    case Syntax.DebuggerStatement:
       return atomize(node, function(node) {
         return buildContinuationCall(k, node);
       });
@@ -277,6 +281,9 @@ function cpsInnerStatement(node, e, fk) {
       return cpsDeclarations(declarations, 0, function(id) {
         return buildContinuation(id, e);
       });
+    }),
+    clause(Syntax.DebuggerStatement, function() {
+      return cps(node, buildContinuation(genvar('dummy'), e));
     })], fail('cpsInnerStatement', node));
 }
 
@@ -311,6 +318,9 @@ function cpsFinalStatement(node, k, fk) {
       return cpsDeclarations(declarations, 0, function(id) {
         return buildContinuation(id, cps(build.identifier('undefined'), k));
       });
+    }),
+    clause(Syntax.DebuggerStatement, function() {
+      return cps(node, k);
     })], fail('cpsFinalStatement', node));
 }
 

--- a/src/transforms/cps.js
+++ b/src/transforms/cps.js
@@ -283,7 +283,7 @@ function cpsInnerStatement(node, e, fk) {
       });
     }),
     clause(Syntax.DebuggerStatement, function() {
-      return cps(node, buildContinuation(genvar('dummy'), e));
+      return cps(node, buildContinuation(genvar('debugger'), e));
     })], fail('cpsInnerStatement', node));
 }
 

--- a/src/transforms/optimize.js
+++ b/src/transforms/optimize.js
@@ -99,6 +99,15 @@ function optimize(node) {
         return node;
       }
 
+    case Syntax.VariableDeclaration:
+      // Un-wrap debugger statements.
+      if (node.declarations.length === 1 &&
+          node.declarations[0].id.name.slice(0, 9) === '_debugger') {
+        return build.debuggerStatement();
+      } else {
+        return node;
+      }
+
     default:
       return node;
   }

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -309,6 +309,14 @@ var tests = {
 
   ],
 
+  testDebuggerStatement: [
+
+    { name: 'test',
+      code: 'debugger; true;',
+      expected: true }
+
+  ],
+
   testBlockStatement: [
 
     { name: 'testProgram',


### PR DESCRIPTION
This enables `debugger` statements in webppl code.

Since the earlier discussion in #38 I've included a post-processing step to remove the immediately invoked wrapping function.

(`debugger` statements which appear as the final statement in a block will still be wrapped but that's fine.)

I think this is good to merge.