### PR TITLE
Pass `env` to additional headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,18 +146,25 @@ Using the example of reading and writing CSV files:
 
 ### Additional header files
 
-Sometimes, it is useful to define external functions that are able to access the store, continuation, and address arguments that are present at any point in a webppl program but usually not exposed to the user. Let's use the example of a function that makes the current address available in WebPPL:
+Sometimes, it is useful to define external functions that are able to access WebPPL internals not usually exposed to the user. Header files have access to the following:
 
-1. Write a Javascript file that exports the functions you want to use:
+* The store, continuation, and address arguments that are present at any point in a WebPPL program.
+* The `env` container which allows access to `env.coroutine` among other things.
+
+Let's use the example of a function that makes the current address available in WebPPL:
+
+1. Write a Javascript file that exports a function. The function will be called with the `env` container and should return an object containing the functions you want to use:
 
         // addressHeader.js
-        
-        function myGetAddress(store, k, address){
-          return k(store, address);
-        };
-        
-        module.exports = {
-          myGetAddress: myGetAddress
+
+        module.exports = function(env) {
+
+          function myGetAddress(store, k, address){
+            return k(store, address);
+          };
+
+          return { myGetAddress: myGetAddress };
+
         };
 
 2. Write a WebPPL file that uses your new functions (without module qualifier):

--- a/src/main.js
+++ b/src/main.js
@@ -24,12 +24,16 @@ var util = require('./util');
 var env = {};
 
 // Make header functions globally available:
-var header = require('./header.js')(env);
-for (var prop in header) {
-  if (header.hasOwnProperty(prop)) {
-    global[prop] = header[prop];
+function requireHeader(path) {
+  var header = require(path)(env);
+  for (var prop in header) {
+    if (header.hasOwnProperty(prop)) {
+      global[prop] = header[prop];
+    }
   }
 }
+
+requireHeader('./header.js');
 
 function concatPrograms(p0, p1) {
   return build.program(p0.body.concat(p1.body));
@@ -137,5 +141,6 @@ module.exports = {
   run: run,
   prepare: prepare,
   compile: compile,
-  analyze: analyze
+  analyze: analyze,
+  requireHeader: requireHeader
 };

--- a/webppl
+++ b/webppl
@@ -11,15 +11,6 @@ function asArray(xs) {
   return (xs ? ((xs instanceof Array) ? xs : [xs]) : []);
 }
 
-function requireAsGlobal(modulePath) {
-  var runtime = require(modulePath);
-  for (var prop in runtime) {
-    if (runtime.hasOwnProperty(prop)) {
-      global[prop] = runtime[prop];
-    }
-  }
-}
-
 function isErp(x) {
   return (x && (x.score != undefined) && (x.sample != undefined));
 }
@@ -71,12 +62,12 @@ function run(code, requires, verbose) {
   requires.forEach(
     function(req) {
       if (req.type === 'require-header'){
-        requireAsGlobal(req.path);
+        webppl.requireHeader(req.path);
       } else if (req.type === 'require-js'){
         global[req.name] = require(req.path);
       } else if (req.type === 'require-wppl') {
         var reqCode = fs.readFileSync(req.path, 'utf8');
-        code = reqCode + ';' + code;        
+        code = reqCode + ';' + code;
       } else {
         throw 'unknown require type: ' + req.type;
       }
@@ -92,7 +83,7 @@ function run(code, requires, verbose) {
 
 function compile(code, requires, verbose, outputFile) {
   var compiledCode = '';
-  requires.push({
+  requires.unshift({
     name: 'webppl', // this makes header.js exports globally available
     path: require.resolve('./src/main'),
     type: 'require-js'
@@ -102,7 +93,7 @@ function compile(code, requires, verbose, outputFile) {
         if (req.type === 'require-js') {
           compiledCode += 'var ' + req.name + " = require('" + req.path + "');\n";
         } else if (req.type === 'require-header') {
-          compiledCode += "requireAsGlobal('" + req.path + "');\n";
+          compiledCode += "webppl.requireHeader('" + req.path + "');\n";
         } else if (req.type === 'require-wppl') {
           var reqCode = fs.readFileSync(req.path, 'utf8');
           code = reqCode + ';' + code;
@@ -114,7 +105,6 @@ function compile(code, requires, verbose, outputFile) {
       isErp.toString() + '\n' +
       isErpWithSupport.toString() + '\n' +
       printWebPPLValue.toString() + '\n' +
-      requireAsGlobal.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +
       ' printWebPPLValue(x); \n};\n\n');
@@ -181,7 +171,7 @@ function main() {
                   });
             });
       });
-  
+
   var processCode = argv.compile ? compile : run;
   var outputFile = argv.out ? argv.out : 'tmp.js';
 


### PR DESCRIPTION
This addresses #122.

Obviously this breaks things for anyone already using the current set-up. We could think about backwards compatibility or informative error messages if you think this will be an issue.