### PR TITLE
Fix browserify

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -102,7 +102,7 @@ module.exports = function(env) {
   // Exports
 
   var exports = {
-    top: util.runningInBrowser() ? window : global
+    _top: util.runningInBrowser() ? window : global
   };
 
   function addExports(obj) {

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -57,15 +57,15 @@ var gamma = function(shape, scale) {
 };
 
 var deltaERP = function(v) {
-  return top.makeDeltaERP(v);
+  return _top.makeDeltaERP(v);
 };
 
 var categoricalERP = function(ps, vs) {
-  return top.makeCategoricalERP(ps, vs);
+  return _top.makeCategoricalERP(ps, vs);
 };
 
 var multiplexERP = function(vs, erps) {
-  return top.makeMultiplexERP(vs, erps);
+  return _top.makeMultiplexERP(vs, erps);
 };
 
 // XRPs

--- a/src/main.js
+++ b/src/main.js
@@ -26,14 +26,20 @@ var env = {};
 // Make header functions globally available:
 function requireHeader(path) {
   var header = require(path)(env);
-  for (var prop in header) {
-    if (header.hasOwnProperty(prop)) {
-      global[prop] = header[prop];
+  makePropertiesGlobal(header);
+}
+
+function makePropertiesGlobal(obj) {
+  for (var prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      global[prop] = obj[prop];
     }
   }
 }
 
-requireHeader('./header.js');
+// Explicitly call require here to ensure that browserify notices that the
+// header should be bundled.
+makePropertiesGlobal(require('./header.js')(env));
 
 function concatPrograms(p0, p1) {
   return build.program(p0.body.concat(p1.body));


### PR DESCRIPTION
This addresses the [problems noted](https://github.com/probmods/webppl/pull/127#issuecomment-117923939) by @hawkrobe.

* I caused the `Cannot find module './header.js'` error with #127, as browersify doesn't notice it needs to bundle a file when you call `require` dynamically. i.e. you need to do `require('./file.js')` rather than `require(path)`.
* forestdb/forestdb.org#6 happens because we try and define `window.top` while adding the stuff in `header.js` as globals, and this is read-only in Safari and Firefox. I've renamed `top` to `_top` to avoid this.

I've tested this in Chrome, Safari and Firefox, webppl now loads in them all.