### PR TITLE
Variable number of factors for ParticleFilterRejuv

### DIFF
--- a/src/inference/mh.js
+++ b/src/inference/mh.js
@@ -7,6 +7,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var erp = require('../erp.js');
 var diagnostics = require('./mh-diagnostics/diagnostics.js')
+var logHist = require('../util.js').logHist;
 
 module.exports = function(env) {
 
@@ -186,7 +187,7 @@ module.exports = function(env) {
 
       return this.sample(_.clone(regen.store), regen.k, regen.name, regen.erp, regen.params, true);
     } else {
-      var dist = erp.makeMarginalERP(util.logHist(this.returnHist));
+      var dist = erp.makeMarginalERP(logHist(this.returnHist));
 
       // Reinstate previous coroutine:
       var k = this.k;

--- a/src/inference/particlefilter.js
+++ b/src/inference/particlefilter.js
@@ -102,7 +102,6 @@ module.exports = function(env) {
     return this.currentParticle().continuation(this.currentParticle().store);
   };
 
-
   // The three functions below return -1 if there is no active particle
 
   ParticleFilter.prototype.firstActiveParticleIndex = function() {
@@ -122,7 +121,6 @@ module.exports = function(env) {
       return nextActiveIndex;
     }
   };
-
 
   ParticleFilter.prototype.currentParticle = function() {
     return this.particles[this.particleIndex];

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -102,7 +102,9 @@ module.exports = function(env) {
             // make sure mhp coroutine doesn't escape:
             assert(env.coroutine.isParticleFilterRejuvCoroutine);
             // if particle has finished, don't rejuvenate
-            if (!particle.active) return nextK();
+            if (!particle.active) {
+              return nextK();
+            }
             // otherwise, rejuvenate
             return new MHP(function(p) {particles[i] = p; return nextK();},
                            particle, this.baseAddress, a,
@@ -111,10 +113,11 @@ module.exports = function(env) {
           function() {
             // Resampling can kill all continuing particles
             var i = this.firstActiveParticleIndex();
-            if (i === -1)
+            if (i === -1) {
               return this.finish(); // All particles completed
-            else
+            } else {
               this.particleIndex = i;
+            }
             return this.currentParticle().continuation(this.currentParticle().store);
           }.bind(this),
           this.particles
@@ -139,10 +142,11 @@ module.exports = function(env) {
   ParticleFilterRejuv.prototype.nextActiveParticleIndex = function() {
     var successorIndex = this.particleIndex + 1;
     var nextActiveIndex = util.indexOfPred(this.particles, isActive, successorIndex);
-    if (nextActiveIndex === -1)
+    if (nextActiveIndex === -1) {
       return this.firstActiveParticleIndex();  // wrap around
-    else
+    } else {
       return nextActiveIndex;
+    }
   };
 
   ParticleFilterRejuv.prototype.currentParticle = function() {
@@ -221,8 +225,9 @@ module.exports = function(env) {
     if (i === -1) {
       return this.finish();     // All particles completed
     } else {
-      if (i < this.particleIndex)
+      if (i < this.particleIndex) {
         this.resampleParticles(); // Updated all particles; now wrap around
+      }
       this.particleIndex = i;
       return this.currentParticle().continuation(this.currentParticle().store);
     }

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -15,6 +15,9 @@ var assert = require('assert');
 var util = require('../util.js');
 var erp = require('../erp.js');
 
+function isActive(particle) {
+  return particle.active;
+}
 
 module.exports = function(env) {
 
@@ -57,15 +60,15 @@ module.exports = function(env) {
         value: undefined,
         trace: [],
         store: _.clone(s),
+        active: true,
         proposalBoundary: 0 // index of first erp to consider for mh proposals
       };
       this.particles.push(particle);
     }
-
   }
 
   ParticleFilterRejuv.prototype.run = function() {
-    return this.activeParticle().continuation(this.activeParticle().store);
+    return this.currentParticle().continuation(this.currentParticle().store);
   };
 
   ParticleFilterRejuv.prototype.sample = function(s, cc, a, erp, params) {
@@ -73,26 +76,22 @@ module.exports = function(env) {
     var val = importanceERP.sample(params);
     var importanceScore = importanceERP.score(params, val);
     var choiceScore = erp.score(params, val);
-    var currScore = this.activeParticle().score;
-    this.activeParticle().trace.push(
-        {
-          k: cc, name: a, erp: erp, params: params,
-          score: currScore,
-          forwardChoiceScore: importanceScore,
-          val: val, reused: false,
-          store: _.clone(s)
-        });
-    this.activeParticle().score += choiceScore;
-    this.activeParticle().weight += choiceScore - importanceScore;
+    var currScore = this.currentParticle().score;
+    this.currentParticle().trace.push(
+        {k: cc, name: a, erp: erp, params: params,
+          score: currScore, forwardChoiceScore: importanceScore,
+          val: val, reused: false, store: _.clone(s)});
+    this.currentParticle().score += choiceScore;
+    this.currentParticle().weight += choiceScore - importanceScore;
     return cc(s, val);
   };
 
   ParticleFilterRejuv.prototype.factor = function(s, cc, a, score) {
     // Update particle weight and score
-    this.activeParticle().weight += score;
-    this.activeParticle().score += score;
-    this.activeParticle().continuation = cc;
-    this.activeParticle().store = _.clone(s);
+    this.currentParticle().weight += score;
+    this.currentParticle().score += score;
+    this.currentParticle().continuation = cc;
+    this.currentParticle().store = _.clone(s);
 
     if (this.allParticlesAdvanced()) {
       // Resample in proportion to weights
@@ -102,33 +101,56 @@ module.exports = function(env) {
           function(particle, i, particles, nextK) {
             // make sure mhp coroutine doesn't escape:
             assert(env.coroutine.isParticleFilterRejuvCoroutine);
-            return new MHP(
-                function(p) {
-                  particles[i] = p;
-                  return nextK();
-                },
-                particle, this.baseAddress,
-                a, this.wpplFn, this.rejuvSteps).run();
+            // if particle has finished, don't rejuvenate
+            if (!particle.active) return nextK();
+            // otherwise, rejuvenate
+            return new MHP(function(p) {particles[i] = p; return nextK();},
+                           particle, this.baseAddress, a,
+                           this.wpplFn, this.rejuvSteps).run();
           }.bind(this),
           function() {
-            this.particleIndex = 0;
-            return this.activeParticle().continuation(this.activeParticle().store);
+            // Resampling can kill all continuing particles
+            var i = this.firstActiveParticleIndex();
+            if (i === -1)
+              return this.finish(); // All particles completed
+            else
+              this.particleIndex = i;
+            return this.currentParticle().continuation(this.currentParticle().store);
           }.bind(this),
           this.particles
       );
     } else {
       // Advance to the next particle
-      this.particleIndex += 1;
-      return this.activeParticle().continuation(this.activeParticle().store);
+      this.particleIndex = this.nextActiveParticleIndex();
+      return this.currentParticle().continuation(this.currentParticle().store);
     }
   };
 
-  ParticleFilterRejuv.prototype.activeParticle = function() {
+  // The three functions below return -1 if there is no active particle
+
+  ParticleFilterRejuv.prototype.firstActiveParticleIndex = function() {
+    return util.indexOfPred(this.particles, isActive);
+  };
+
+  ParticleFilterRejuv.prototype.lastActiveParticleIndex = function() {
+    return util.lastIndexOfPred(this.particles, isActive);
+  };
+
+  ParticleFilterRejuv.prototype.nextActiveParticleIndex = function() {
+    var successorIndex = this.particleIndex + 1;
+    var nextActiveIndex = util.indexOfPred(this.particles, isActive, successorIndex);
+    if (nextActiveIndex === -1)
+      return this.firstActiveParticleIndex();  // wrap around
+    else
+      return nextActiveIndex;
+  };
+
+  ParticleFilterRejuv.prototype.currentParticle = function() {
     return this.particles[this.particleIndex];
   };
 
   ParticleFilterRejuv.prototype.allParticlesAdvanced = function() {
-    return ((this.particleIndex + 1) === this.particles.length);
+    return this.particleIndex === this.lastActiveParticleIndex();
   };
 
   function copyPFRParticle(particle) {
@@ -138,13 +160,13 @@ module.exports = function(env) {
       value: particle.value,
       score: particle.score,
       store: _.clone(particle.store),
+      active: particle.active,
       trace: deepCopyTrace(particle.trace),
       proposalBoundary: particle.proposalBoundary
     };
   }
 
   ParticleFilterRejuv.prototype.resampleParticles = function() {
-
     // Residual resampling following Liu 2008; p. 72, section 3.4.4
     var m = this.particles.length;
     var W = util.logsumexp(_.map(this.particles, function(p) {
@@ -191,16 +213,22 @@ module.exports = function(env) {
   };
 
   ParticleFilterRejuv.prototype.exit = function(s, retval) {
-
-    this.activeParticle().value = retval;
-
+    this.currentParticle().value = retval;
+    this.currentParticle().active = false;
     // Wait for all particles to reach exit before computing
     // marginal distribution from particles
-    if (!this.allParticlesAdvanced()) {
-      this.particleIndex += 1;
-      return this.activeParticle().continuation(this.activeParticle().store);
+    var i = this.nextActiveParticleIndex();
+    if (i === -1) {
+      return this.finish();     // All particles completed
+    } else {
+      if (i < this.particleIndex)
+        this.resampleParticles(); // Updated all particles; now wrap around
+      this.particleIndex = i;
+      return this.currentParticle().continuation(this.currentParticle().store);
     }
+  };
 
+  ParticleFilterRejuv.prototype.finish = function() {
     // Initialize histogram with particle values
     var hist = {};
     this.particles.forEach(function(particle) {
@@ -215,15 +243,12 @@ module.exports = function(env) {
     var oldStore = this.oldStore;
     return util.cpsForEach(
         function(particle, i, particles, nextK) {
+          // no need to check for inactive particles here
           // make sure mhp coroutine doesn't escape:
           assert(env.coroutine.isParticleFilterRejuvCoroutine);
-          return new MHP(
-              function(p) {
-                particles[i] = p;
-                return nextK();
-              },
-              particle, this.baseAddress, undefined,
-              this.wpplFn, this.rejuvSteps, hist).run();
+          return new MHP(function(p) {particles[i] = p; return nextK();},
+                         particle, this.baseAddress, undefined,
+                         this.wpplFn, this.rejuvSteps, hist).run();
         }.bind(this),
         function() {
           var dist = erp.makeMarginalERP(util.logHist(hist));
@@ -244,7 +269,6 @@ module.exports = function(env) {
   };
 
   ParticleFilterRejuv.prototype.incrementalize = env.defaultCoroutine.incrementalize;
-
 
   ////// Lightweight MH on a particle
 
@@ -304,7 +328,6 @@ module.exports = function(env) {
     return this.sample(_.clone(regen.store), regen.k, regen.name, regen.erp, regen.params, true);
   };
 
-
   MHP.prototype.exit = function(s, val) {
 
     this.val = val;
@@ -351,6 +374,7 @@ module.exports = function(env) {
         value: this.val,
         score: this.currScore,
         store: this.oldStore, // use store from latest accepted proposal
+        active: this.originalParticle.active,
         trace: this.trace,
         proposalBoundary: this.originalParticle.proposalBoundary
       };
@@ -367,7 +391,7 @@ module.exports = function(env) {
   // Restrict rejuvenation to erps that come after proposal boundary
   function setProposalBoundary(s, k, a) {
     if (env.coroutine.isParticleFilterRejuvCoroutine) {
-      var particle = env.coroutine.activeParticle();
+      var particle = env.coroutine.currentParticle();
       particle.proposalBoundary = particle.trace.length;
     }
     return k(s);

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -117,6 +117,8 @@ var tests = [
       store: { hist: { tol: 0 }, args: [30, 30] },
       geometric: true,
       drift: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [1000, 15] },
+      varFactors1: { args: [5000, 0] },
+      varFactors2: true,
       importance: true,
       importance2: { args: [3000, 10] },
       withCaching: true
@@ -134,6 +136,8 @@ var tests = [
       simple: true,
       store: { hist: { tol: 0 }, args: [1, 100] },
       geometric: true,
+      varFactors1: { args: [5000, 0] },
+      varFactors2: true,
       importance: true,
       importance2: true,
       withCaching: true
@@ -145,14 +149,17 @@ var tests = [
     settings: {
       args: [1000, 0],
       hist: { tol: 0.1 },
+      logZ: { check: true, tol: 0.1 },
       MAP: { tol: 0.1, check: true }
     },
     models: {
       simple: true,
-      importance: true,
-      importance2: { args: [3000, 0] },
       store: { hist: { tol: 0 }, args: [100, 0] },
       gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [10000, 0] },
+      varFactors1: { args: [5000, 0] },
+      varFactors2: true,
+      importance: true,
+      importance2: { args: [3000, 0] },
       withCaching: true
       // varFactors1: { args: [5000, 0] },
       // varFactors2: true


### PR DESCRIPTION
This nominally sorts out #118.
When particles have different number of factors, at the resampling stage, the rejuvenation is only carried out on the still-`active` particles. There may be a case for adopting a different scheme where the `inactive` particles get rejuvenated again as well.
The final rejuvenation still works as it should, over all the particles.