### PR TITLE
Combine duplicated isErp functions.

### DIFF
--- a/src/erp.js
+++ b/src/erp.js
@@ -567,6 +567,14 @@ var makeMultiplexERP = function(vs, erps) {
   );
 };
 
+function isErp(x) {
+  return x && _.isFunction(x.score) && _.isFunction(x.sample);
+}
+
+function isErpWithSupport(x) {
+  return isErp(x) && _.isFunction(x.support);
+}
+
 module.exports = {
   ERP: ERP,
   bernoulliERP: bernoulliERP,
@@ -584,5 +592,7 @@ module.exports = {
   uniformERP: uniformERP,
   makeMarginalERP: makeMarginalERP,
   makeCategoricalERP: makeCategoricalERP,
-  makeMultiplexERP: makeMultiplexERP
+  makeMultiplexERP: makeMultiplexERP,
+  isErp: isErp,
+  isErpWithSupport: isErpWithSupport
 };

--- a/src/util.js
+++ b/src/util.js
@@ -165,14 +165,6 @@ function getOpt(optObject, option, defaultValue) {
       defaultValue;
 }
 
-function isErp(x) {
-  return x && _.isFunction(x.score) && _.isFunction(x.sample);
-}
-
-function isErpWithSupport(x) {
-  return isErp(x) && _.isFunction(x.support);
-}
-
 module.exports = {
   copyObj: copyObj,
   cpsForEach: cpsForEach,
@@ -192,7 +184,5 @@ module.exports = {
   std: std,
   getOpt: getOpt,
   sum: sum,
-  asArray: asArray,
-  isErp: isErp,
-  isErpWithSupport: isErpWithSupport
+  asArray: asArray
 };

--- a/src/util.js
+++ b/src/util.js
@@ -165,6 +165,14 @@ function getOpt(optObject, option, defaultValue) {
       defaultValue;
 }
 
+function isErp(x) {
+  return x && _.isFunction(x.score) && _.isFunction(x.sample);
+}
+
+function isErpWithSupport(x) {
+  return isErp(x) && _.isFunction(x.support);
+}
+
 module.exports = {
   copyObj: copyObj,
   cpsForEach: cpsForEach,
@@ -184,5 +192,7 @@ module.exports = {
   std: std,
   getOpt: getOpt,
   sum: sum,
-  asArray: asArray
+  asArray: asArray,
+  isErp: isErp,
+  isErpWithSupport: isErpWithSupport
 };

--- a/tests/test-examples.js
+++ b/tests/test-examples.js
@@ -3,6 +3,7 @@
 var _ = require('underscore');
 var fs = require('fs');
 var webppl = require('../src/main.js');
+var erp = require('../src/erp');
 
 var examplesDir = './examples/';
 
@@ -28,8 +29,8 @@ var generateTestCases = function() {
   _.each(examples, function(example) {
     exports[example] = function(test) {
       test.doesNotThrow(function() {
-        webppl.run(loadExample(example), function(s, erp) {
-          test.ok(util.isErp(erp));
+        webppl.run(loadExample(example), function(s, val) {
+          test.ok(erp.isErp(val));
         });
       });
       test.done();

--- a/tests/test-examples.js
+++ b/tests/test-examples.js
@@ -24,18 +24,12 @@ var loadExample = function(example) {
   return fs.readFileSync(filename, 'utf-8');
 };
 
-var isErp = function(erp) {
-  return _.every(['sample', 'support', 'sample'], function(property) {
-    return _.isFunction(erp[property]);
-  })
-};
-
 var generateTestCases = function() {
   _.each(examples, function(example) {
     exports[example] = function(test) {
       test.doesNotThrow(function() {
         webppl.run(loadExample(example), function(s, erp) {
-          test.ok(isErp(erp));
+          test.ok(util.isErp(erp));
         });
       });
       test.done();

--- a/webppl
+++ b/webppl
@@ -11,7 +11,7 @@ var git = require('git-rev-2');
 var _ = require('underscore');
 
 function printWebPPLValue(x) {
-  if (util.isErpWithSupport(x)) {
+  if (isErpWithSupport(x)) {
     console.log('ERP:');
     var erpValues = x.support([])
       .map(function(v) {

--- a/webppl
+++ b/webppl
@@ -10,16 +10,8 @@ var parseArgs = require('minimist');
 var git = require('git-rev-2');
 var _ = require('underscore');
 
-function isErp(x) {
-  return (x && (x.score != undefined) && (x.sample != undefined));
-}
-
-function isErpWithSupport(x) {
-  return (isErp(x) && (x.support != undefined));
-}
-
 function printWebPPLValue(x) {
-  if (isErpWithSupport(x)) {
+  if (util.isErpWithSupport(x)) {
     console.log('ERP:');
     var erpValues = x.support([])
       .map(function(v) {
@@ -69,8 +61,6 @@ function compile(code, packages, verbose, outputFile) {
   });
 
   compiledCode += (
-      isErp.toString() + '\n' +
-      isErpWithSupport.toString() + '\n' +
       printWebPPLValue.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +


### PR DESCRIPTION
I need `isErp` in #64 so it would be nice to put it somewhere re-usable.

I considered putting it in `erp.js` rather than `util.js` but that felt a little odd because `isErp` becomes available at the top-level in webppl code but it isn't in CPS. I'm open to better suggestions if you have any?

I've checked this works from the command line with and without the `--compile` option.

A nice (though small) side-effect of this is I think we could use `util.isErp` in dippl [here](https://github.com/probmods/dippl/blob/15257640c73961cb7f38285347389ffa88f37e9d/assets/js/custom.js#L16).
