### PR TITLE
Add nodejs v4.0.0 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
+  - "4.0.0"
 
 install:
   - npm install


### PR DESCRIPTION
On my computer, node v4 is substantially faster than the previous v0.12 (for `time grunt`):

node v0.12.0:
real	1m57.713s
user	1m56.988s
sys	0m1.264s

node v4.0.0:
real	1m30.897s
user	1m29.823s
sys	0m1.237s