### PR TITLE
Default to depth first search for complete enumeration

### DIFF
--- a/src/inference/enumerate.js
+++ b/src/inference/enumerate.js
@@ -171,11 +171,13 @@ module.exports = function(env) {
     return new Enumerate(s, cc, a, wpplFn, maxExecutions, q).run();
   }
 
+  function enuDefault(s, cc, a, wpplFn, maxExecutions) {
+    var enu = _.isFinite(maxExecutions) ? enuPriority : enuFilo;
+    return enu(s, cc, a, wpplFn, maxExecutions);
+  }
+
   return {
-    Enumerate: function(s, cc, a, wpplFn, maxExecutions) {
-      var enu = _.isFinite(maxExecutions) ? enuPriority : enuFilo;
-      return enu(s, cc, a, wpplFn, maxExecutions);
-    },
+    Enumerate: enuDefault,
     EnumerateBreadthFirst: enuFifo,
     EnumerateDepthFirst: enuFilo,
     EnumerateLikelyFirst: enuPriority

--- a/src/inference/enumerate.js
+++ b/src/inference/enumerate.js
@@ -172,7 +172,10 @@ module.exports = function(env) {
   }
 
   return {
-    Enumerate: enuPriority,
+    Enumerate: function(s, cc, a, wpplFn, maxExecutions) {
+      var enu = _.isFinite(maxExecutions) ? enuPriority : enuFilo;
+      return enu(s, cc, a, wpplFn, maxExecutions);
+    },
     EnumerateBreadthFirst: enuFifo,
     EnumerateDepthFirst: enuFilo,
     EnumerateLikelyFirst: enuPriority

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -33,7 +33,7 @@ var tests = [
   {
     name: 'Enumerate',
     settings: {
-      args: [10],
+      args: [],
       MAP: { check: true }
     },
     models: {
@@ -41,7 +41,7 @@ var tests = [
       upweight: true,
       incrementalBinomial: true,
       store: { hist: { tol: 0 } },
-      geometric: true,
+      geometric: { args: [10] },
       cache: true,
       stochasticCache: true,
       withCaching: true,
@@ -262,7 +262,7 @@ var wpplRunInference = function(modelName, testDef) {
   var inferenceArgs = getInferenceArgs(testDef, modelName);
   var progText = [
     helpers.loadModel(testDataDir, modelName),
-    inferenceFunc, '(model,', inferenceArgs, ');'
+    inferenceFunc, '(', ['model'].concat(inferenceArgs).join(', '), ');'
   ].join('');
   var erp;
   webppl.run(progText, function(s, val) { erp = val; });
@@ -291,7 +291,7 @@ var performTest = function(modelName, testDef, test) {
 
 var getInferenceArgs = function(testDef, model) {
   var args = (testDef.models[model] && testDef.models[model].args) || testDef.settings.args;
-  return JSON.stringify(args).slice(1, -1);
+  return args.map(JSON.stringify);
 };
 
 var testFunctions = {


### PR DESCRIPTION
This addresses #175. Inference tests exercise both paths through `Enumerate`.