### PR TITLE
Have ERP.prototype.print show the ERP name for non-serializable ERP

### DIFF
--- a/src/erp.js
+++ b/src/erp.js
@@ -80,21 +80,25 @@ ERP.prototype.withParameters = function(params) {
   return erp;
 };
 
+ERP.prototype.isSerializeable = function() {
+  return this.support && !this.parameterized;
+};
+
 // ERP serializer (allows JSON.stringify)
 ERP.prototype.toJSON = function() {
-  if (this.parameterized || this.support === undefined) {
-    throw 'Cannot serialize ' + this.name + ' ERP.';
-  } else {
+  if (this.isSerializeable()) {
     var support = this.support([]);
     var probs = support.map(function(s) {return Math.exp(this.score([], s));}, this);
     var erpJSON = {probs: probs, support: support};
     this.toJSON = function() {return erpJSON};
     return erpJSON;
+  } else {
+    throw 'Cannot serialize ' + this.name + ' ERP.';
   }
 };
 
 ERP.prototype.print = function() {
-  if (this.support && !this.parameterized) {
+  if (this.isSerializeable()) {
     console.log('ERP:');
     var json = this.toJSON();
     _.zip(json.probs, json.support)

--- a/src/erp.js
+++ b/src/erp.js
@@ -94,11 +94,17 @@ ERP.prototype.toJSON = function() {
 };
 
 ERP.prototype.print = function() {
-  console.log('ERP:');
-  var json = this.toJSON();
-  _.zip(json.probs, json.support)
-    .sort(function(a, b) { return b[0] - a[0]; })
-    .forEach(function(val) {console.log('    ' + util.serialize(val[1]) + ' : ' + val[0]);})
+  if (this.support && !this.parameterized) {
+    console.log('ERP:');
+    var json = this.toJSON();
+    _.zip(json.probs, json.support)
+      .sort(function(a, b) { return b[0] - a[0]; })
+      .forEach(function(val) {
+          console.log('    ' + util.serialize(val[1]) + ' : ' + val[0]);
+        });
+  } else {
+    console.log('[ERP: ' + this.name + ']');
+  }
 };
 
 var serializeERP = function(erp) {


### PR DESCRIPTION
We could do something better than this of course, but this is better than throwing an exception I think.