### PR TITLE
Make IncrementalMH work with models with zero ERP

### DIFF
--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -916,18 +916,22 @@ module.exports = function(env) {
         if (this.doAdapt)
           this.cacheAdapter.adapt(this.cacheRoot);
 
-        // Prepare to make a new proposal
-        this.oldScore = this.score;
-        this.erpMasterList.preProposal();
-        this.touchedNodes = [];
-        this.fwdPropLP = 0;
-        this.rvsPropLP = 0;
-        // Select ERP to change.
-        var propnode = this.erpMasterList.getRandom();
-        // Propose change and resume execution
-        debuglog(1, '----------------------------------------------------------------------');
-        debuglog(1, 'PROPOSAL', 'type:', propnode.erp.sample.name, 'address:', propnode.address);
-        return propnode.propose();
+        if (this.erpMasterList.numErps > 0) {
+          // Prepare to make a new proposal
+          this.oldScore = this.score;
+          this.erpMasterList.preProposal();
+          this.touchedNodes = [];
+          this.fwdPropLP = 0;
+          this.rvsPropLP = 0;
+          // Select ERP to change.
+          var propnode = this.erpMasterList.getRandom();
+          // Propose change and resume execution
+          debuglog(1, '----------------------------------------------------------------------');
+          debuglog(1, 'PROPOSAL', 'type:', propnode.erp.sample.name, 'address:', propnode.address);
+          return propnode.propose();
+        } else {
+          return this.runFromStart();
+        }
       }
     } else {
       var dist;

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -30,7 +30,7 @@ module.exports = function(env) {
   MHKernel.prototype.run = function() {
     var numERP = this.oldTrace.length - this.proposalBoundary;
     if (numERP === 0) {
-      return this.cont(this.oldTrace, false);
+      return this.cont(this.oldTrace, true);
     }
     // Make a new proposal.
     env.query.clear();

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -44,6 +44,7 @@ var tests = [
       simple: true,
       upweight: true,
       incrementalBinomial: true,
+      deterministic: { hist: { tol: 0 } },
       store: { hist: { tol: 0 } },
       geometric: { args: [10] },
       cache: true,
@@ -81,6 +82,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
+      deterministic: { hist: { tol: 0 }, args: [30, 30] },
       store: { hist: { tol: 0 }, args: [30, 30] },
       gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [1000, 100] },
       withCaching: true,
@@ -111,6 +113,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
+      deterministic: { hist: { tol: 0 } },
       upweight: { args: [1000, 10] },
       incrementalBinomial: { args: [1000, -2] },
       store: { hist: { tol: 0 } },
@@ -197,6 +200,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
+      deterministic: { hist: { tol: 0 }, args: { particles: 1, rejuvSteps: 100 } },
       store: { hist: { tol: 0 }, args: { particles: 1, rejuvSteps: 100 } },
       store2: { hist: { tol: 0 }, args: { particles: 1, rejuvSteps: 100 } },
       geometric: true,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -61,6 +61,7 @@ var tests = [
     },
     models: {
       simple: true,
+      deterministic: { hist: { tol: 0 }, args: [100] },
       cache: true,
       store: { hist: { tol: 0 }, args: [100] },
       geometric: true,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -150,7 +150,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
-      deterministic: true,
+      deterministic: { hist: { tol: 0 }, args: { particles: 100 } },
       store: { hist: { tol: 0 }, args: { particles: 100 } },
       store2: { hist: { tol: 0 }, args: { particles: 100 } },
       gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { particles: 10000 } },
@@ -174,7 +174,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
-      deterministic: true,
+      deterministic: { hist: { tol: 0 }, args: { particles: 30, rejuvSteps: 30 } },
       store: { hist: { tol: 0 }, args: { particles: 30, rejuvSteps: 30 } },
       store2: { hist: { tol: 0 }, args: { particles: 30, rejuvSteps: 30 } },
       geometric: true,
@@ -217,7 +217,7 @@ var tests = [
     models: {
       simple: true,
       cache: true,
-      deterministic: { args: { samples: 1000 } },
+      deterministic: { hist: { tol: 0 }, args: { samples: 100 } },
       store: { hist: { tol: 0 }, args: { samples: 100 } },
       geometric: true,
       gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { samples: 80000, burn: 20000 } },


### PR DESCRIPTION
This resolves #155 for IncrementalMH. I chose to `runFromStart` rather than bail out of inference altogether for consistency with `MCMC` + `MHKernel`. I've tweaked `MHKernel` so that for deterministic models both MH implementations now report an acceptance ratio of 1.