### PR TITLE
Fix IncrementalMH justSample option

### DIFF
--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -934,11 +934,14 @@ module.exports = function(env) {
         }
       }
     } else {
-      var dist;
-      if (this.returnHist)
-        dist = erp.makeMarginalERP(util.logHist(this.returnHist));
-      else
-        dist = erp.makeMarginalERP({});
+      var hist;
+      if (!this.returnSamps && !this.onlyMAP) {
+        hist = this.returnHist;
+      } else {
+        hist = {};
+        hist[JSON.stringify(this.MAP.value)] = { prob: 1, val: this.MAP.value };
+      }
+      var dist = erp.makeMarginalERP(util.logHist(hist));
       if (this.returnSamps) {
         if (this.onlyMAP)
           this.returnSamps.push(this.MAP);

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -935,11 +935,11 @@ module.exports = function(env) {
       }
     } else {
       var hist;
-      if (!this.returnSamps && !this.onlyMAP) {
-        hist = this.returnHist;
-      } else {
+      if (this.returnSamps || this.onlyMAP) {
         hist = {};
         hist[JSON.stringify(this.MAP.value)] = { prob: 1, val: this.MAP.value };
+      } else {
+        hist = this.returnHist;
       }
       var dist = erp.makeMarginalERP(util.logHist(hist));
       if (this.returnSamps) {

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -74,6 +74,26 @@ var tests = [
     }
   },
   {
+    name: 'IMHjustSample',
+    func: 'IncrementalMH',
+    settings: {
+      args: [100, { justSample: true }]
+    },
+    models: {
+      deterministic: { hist: { tol: 0 } }
+    }
+  },
+  {
+    name: 'IMHonlyMAP',
+    func: 'IncrementalMH',
+    settings: {
+      args: [100, { onlyMAP: true }]
+    },
+    models: {
+      deterministic: { hist: { tol: 0 } }
+    }
+  },
+  {
     name: 'PMCMC',
     settings: {
       args: [1000, 5],

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -66,7 +66,7 @@ var tests = [
       cache: true,
       store: { hist: { tol: 0 }, args: [100] },
       geometric: true,
-      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [100000, 20000] },
+      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [100000] },
       withCaching: true,
       optionalErpParams: true,
       variableSupport: true,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -259,7 +259,28 @@ var tests = [
       variableSupport: true,
       query: true
     }
+  },
+  {
+    name: 'MHonlyMAP',
+    func: 'MCMC',
+    settings: {
+      args: { samples: 100, onlyMAP: true }
+    },
+    models: {
+      deterministic: { hist: { tol: 0 } }
+    }
+  },
+  {
+    name: 'MHjustSample',
+    func: 'MCMC',
+    settings: {
+      args: { samples: 100, justSample: true }
+    },
+    models: {
+      deterministic: { hist: { tol: 0 } }
+    }
   }
+
 ];
 
 var wpplRunInference = function(modelName, testDef) {


### PR DESCRIPTION
Since b5253da `makeMarginalERP ` hasn't accepted an empty histogram, so IncrementalMH with these options now returns a marginal distribution which is a delta distribution on the MAP estimate. Fixes #160.