### PR TITLE
Use seedable PRNG for inference tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-gjslint": "^0.1.6",
     "nodeunit": "^0.9.1",
+    "seedrandom": "^2.4.2",
     "through2": "^2.0.0"
   },
   "scripts": {

--- a/src/erp.js
+++ b/src/erp.js
@@ -128,7 +128,7 @@ var deserializeERP = function(JSONString) {
 
 var uniformERP = new ERP({
   sample: function(params) {
-    var u = Math.random();
+    var u = util.random();
     return (1 - u) * params[0] + u * params[1];
   },
   score: function(params, val) {
@@ -142,7 +142,7 @@ var uniformERP = new ERP({
 var bernoulliERP = new ERP({
   sample: function(params) {
     var weight = params[0];
-    var val = Math.random() < weight;
+    var val = util.random() < weight;
     return val;
   },
   score: function(params, val) {
@@ -166,7 +166,7 @@ var bernoulliERP = new ERP({
 
 var randomIntegerERP = new ERP({
   sample: function(params) {
-    return Math.floor(Math.random() * params[0]);
+    return Math.floor(util.random() * params[0]);
   },
   score: function(params, val) {
     var stop = params[0];
@@ -183,8 +183,8 @@ function gaussianSample(params) {
   var sigma = params[1];
   var u, v, x, y, q;
   do {
-    u = 1 - Math.random();
-    v = 1.7156 * (Math.random() - 0.5);
+    u = 1 - util.random();
+    v = 1.7156 * (util.random() - 0.5);
     x = u - 0.449871;
     y = Math.abs(v) + 0.386595;
     q = x * x + y * (0.196 * y - 0.25472 * x);
@@ -266,7 +266,7 @@ function gammaSample(params) {
   var a = params[0];
   var b = params[1];
   if (a < 1) {
-    return gammaSample([1 + a, b]) * Math.pow(Math.random(), 1 / a);
+    return gammaSample([1 + a, b]) * Math.pow(util.random(), 1 / a);
   }
   var x, v, u;
   var d = a - 1 / 3;
@@ -277,7 +277,7 @@ function gammaSample(params) {
       v = 1 + c * x;
     } while (v <= 0);
     v = v * v * v;
-    u = Math.random();
+    u = util.random();
     if ((u < 1 - 0.331 * x * x * x * x) || (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v)))) {
       return b * d * v;
     }
@@ -298,7 +298,7 @@ var gammaERP = new ERP({
 var exponentialERP = new ERP({
   sample: function(params) {
     var a = params[0];
-    var u = Math.random();
+    var u = util.random();
     return Math.log(u) / (-1 * a);
   },
   score: function(params, val) {
@@ -363,7 +363,7 @@ function binomialSample(params) {
   }
   var u;
   for (var i = 0; i < n; i++) {
-    u = Math.random();
+    u = util.random();
     if (u < p) {
       k++;
     }
@@ -452,7 +452,7 @@ var poissonERP = new ERP({
     var emu = Math.exp(-mu);
     var p = 1;
     do {
-      p *= Math.random();
+      p *= util.random();
       k++;
     } while (p > emu);
     return (k - 1) || 0;
@@ -499,7 +499,7 @@ var dirichletERP = new ERP({ sample: dirichletSample, score: dirichletScore });
 
 function multinomialSample(theta) {
   var thetaSum = util.sum(theta);
-  var x = Math.random() * thetaSum;
+  var x = util.random() * thetaSum;
   var k = theta.length;
   var probAccum = 0;
   for (var i = 0; i < k; i++) {
@@ -535,7 +535,7 @@ function makeMarginalERP(marginal) {
   // Make an ERP from marginal:
   var dist = new ERP({
     sample: function(params) {
-      var x = Math.random();
+      var x = util.random();
       var probAccum = 0;
       for (var i in marginal) {if (marginal.hasOwnProperty(i)) {
         probAccum += marginal[i].prob;

--- a/src/hashtable.js
+++ b/src/hashtable.js
@@ -376,9 +376,9 @@ function Hashtable() {
     // console.log("SIZE: " + size);
     var L = biggestBucket.entries.length;
     while (true) {
-      var bi = Math.floor(Math.random() * buckets.length);
+      var bi = Math.floor(util.random() * buckets.length);
       var bucket = buckets[bi];
-      var p = Math.floor(Math.random() * L);
+      var p = Math.floor(util.random() * L);
       if (p < bucket.entries.length)
         return bucket.entries[p][1];
     }

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -51,7 +51,7 @@ module.exports = function(env) {
       var args = Array.prototype.slice.call(arguments, 3);
       var stringedArgs = JSON.stringify(args);
       var foundInCache = stringedArgs in c;
-      var recomp = Math.random() < recompProb;
+      var recomp = util.random() < recompProb;
       if (foundInCache && !recomp) {      // return stored value
         return k(s, c[stringedArgs]);
       } else {                           // recompute

--- a/src/inference/asyncpf.js
+++ b/src/inference/asyncpf.js
@@ -66,7 +66,7 @@ module.exports = function(env) {
 
     // launch a new particle OR continue an existing one
     var p, launchP;
-    var i = Math.floor((this.buffer.length + 1) * Math.random());
+    var i = Math.floor((this.buffer.length + 1) * util.random());
     if (i == this.buffer.length) { // generate new particle
       p = initParticle(this.store, this.exitK);
     } else {                    // launch particle in queue
@@ -122,7 +122,7 @@ module.exports = function(env) {
 
       // compute number of children and their weights
       if (logRatio < 0) {
-        numChildrenAndWeight = Math.log(Math.random()) < logRatio ?
+        numChildrenAndWeight = Math.log(util.random()) < logRatio ?
             [1, wbar] :
             [0, -Infinity];
       } else {

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -564,7 +564,7 @@ module.exports = function(env) {
   };
 
   ArrayERPMasterList.prototype.getRandom = function() {
-    var idx = Math.floor(Math.random() * this.erpNodes.length);
+    var idx = Math.floor(util.random() * this.erpNodes.length);
     return this.erpNodes[idx];
   };
 
@@ -862,7 +862,7 @@ module.exports = function(env) {
                                     this.rvsPropLP, this.fwdPropLP);
         debuglog(1, 'num vars:', this.erpMasterList.size(), 'old num vars:', this.erpMasterList.oldSize());
         debuglog(1, 'acceptance prob:', acceptance);
-        if (Math.random() >= acceptance) {
+        if (util.random() >= acceptance) {
           debuglog(1, 'REJECT');
           this.score = this.oldScore;
           var n = this.touchedNodes.length;

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -34,7 +34,7 @@ module.exports = function(env) {
     }
     // Make a new proposal.
     env.query.clear();
-    this.regenFrom = this.proposalBoundary + Math.floor(Math.random() * numERP);
+    this.regenFrom = this.proposalBoundary + Math.floor(util.random() * numERP);
     this.trace = this.oldTrace.upto(this.regenFrom);
     var regen = this.oldTrace.choiceAtIndex(this.regenFrom);
     return this.sample(_.clone(regen.store), regen.k, regen.address, regen.erp, regen.params, true);
@@ -90,7 +90,7 @@ module.exports = function(env) {
       assert(!this.trace.isComplete(), 'Particle missed exit address during rejuvenation.');
     }
     var prob = acceptProb(this.trace, this.oldTrace, this.regenFrom, this.reused, this.proposalBoundary);
-    var accept = Math.random() < prob;
+    var accept = util.random() < prob;
     return this.cont(accept ? this.trace : this.oldTrace, accept);
   };
 

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -32,7 +32,7 @@ module.exports = function(env) {
 
   Rejection.prototype.run = function() {
     this.scoreSoFar = 0;
-    this.threshold = this.maxScore + Math.log(Math.random());
+    this.threshold = this.maxScore + Math.log(util.random());
     return this.wpplFn(_.clone(this.s), env.exit, this.a);
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -2,7 +2,6 @@
 
 var _ = require('underscore');
 var assert = require('assert');
-var process = require('process');
 var seedrandom = require('seedrandom');
 
 var rng = Math.random;

--- a/src/util.js
+++ b/src/util.js
@@ -2,7 +2,30 @@
 
 var _ = require('underscore');
 var assert = require('assert');
+var process = require('process');
+var seedrandom = require('seedrandom');
 
+var rng = Math.random;
+
+function random() {
+  return rng();
+}
+
+function seedRNG(seed) {
+  rng = seedrandom(seed);
+}
+
+function resetRNG() {
+  rng = Math.random;
+}
+
+function getRandomSeedFromEnv() {
+  if (process.env.RANDOM_SEED) {
+    var seed = parseInt(process.env.RANDOM_SEED);
+    assert(_.isFinite(seed), 'Random seed should be an integer.');
+    return seed;
+  }
+}
 
 function runningInBrowser() {
   return (typeof window !== 'undefined');
@@ -225,6 +248,10 @@ function deserialize(o) {
 }
 
 module.exports = {
+  random: random,
+  seedRNG: seedRNG,
+  resetRNG: resetRNG,
+  getRandomSeedFromEnv: getRandomSeedFromEnv,
   copyObj: copyObj,
   cpsForEach: cpsForEach,
   cpsLoop: cpsLoop,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
+var seedrandom = require('seedrandom');
 var fs = require('fs');
 var assert = require('assert');
 var util = require('../src/util');
@@ -314,13 +315,24 @@ var getHist = function(erp) {
   return util.normalizeHist(hist);
 };
 
-var generateTestCases = function() {
+var generateTestCases = function(seed) {
   _.each(tests, function(testDef) {
     exports[testDef.name] = {};
     _.each(_.keys(testDef.models), function(modelName) {
       exports[testDef.name][modelName] = _.partial(performTest, modelName, testDef);
     });
   });
+  var random = Math.random;
+  exports.setUp = function(callback) {
+    Math.random = seedrandom(seed);
+    callback();
+  };
+  exports.tearDown = function(callback) {
+    Math.random = random;
+    callback();
+  };
 };
 
-generateTestCases();
+var seed = process.env.RANDOM_SEED ? parseInt(process.env.RANDOM_SEED) : seedrandom().int32();
+console.log('Random seed: ' + seed);
+generateTestCases(seed);

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -322,17 +322,16 @@ var generateTestCases = function(seed) {
       exports[testDef.name][modelName] = _.partial(performTest, modelName, testDef);
     });
   });
-  var random = Math.random;
   exports.setUp = function(callback) {
-    Math.random = seedrandom(seed);
+    util.seedRNG(seed);
     callback();
   };
   exports.tearDown = function(callback) {
-    Math.random = random;
+    util.resetRNG();
     callback();
   };
 };
 
-var seed = process.env.RANDOM_SEED ? parseInt(process.env.RANDOM_SEED) : seedrandom().int32();
+var seed = util.getRandomSeedFromEnv() || seedrandom().int32();
 console.log('Random seed: ' + seed);
 generateTestCases(seed);

--- a/webppl
+++ b/webppl
@@ -113,6 +113,11 @@ function main() {
     return pkg.read(name_or_path, packagePaths, argv.verbose)
   });
 
+  var seed = util.getRandomSeedFromEnv();
+  if (seed !== undefined) {
+    util.seedRNG(seed);
+  }
+
   processCode(code, packages, argv.verbose, outputFile);
 }
 


### PR DESCRIPTION
Each inference test is run with `Math.random` seeded with a particular value. This value changes across runs of the test suite, but within a run is the same for all inference tests. The random seed is logged to the console when the tests run.

If one (or more) tests fail you can replicate the failure without running the entire test suite by running something like:

````
RANDOM_SEED=1033080963 nodeunit tests/test-inference.js -f 'MH - simple'
````

The only downside I can think of with this approach is that we're not testing inference with V8's `Math.random` at all, so there's a chance that we could miss something. I'm not sure this is very likely to happen, but if we were concerned we could set things up so we do an extra run of the test suite on Travis without the seedable RNG.

Closes #143.