### PR TITLE
Re-throw errors encountered during tests.

### DIFF
--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -249,9 +249,14 @@ var wpplRunInference = function(modelName, testDef) {
     helpers.loadModel(testDataDir, modelName),
     inferenceFunc, '(', ['model'].concat(inferenceArgs).join(', '), ');'
   ].join('');
-  var retVal;
-  webppl.run(progText, function(store, erp) { retVal = { store: store, erp: erp }; });
-  return retVal;
+  try {
+    var retVal;
+    webppl.run(progText, function(store, erp) { retVal = { store: store, erp: erp }; });
+    return retVal;
+  } catch (e) {
+    console.log('Exception: ' + e);
+    throw e;
+  }
 };
 
 var performTest = function(modelName, testDef, test) {


### PR DESCRIPTION
We used to have this, but I removed it because I mistakenly thought it was no longer useful. I was wrong, without this the arg passed to `throw` statements in inference algorithms is swallowed by the testing machinery which makes debugging tricky.