### PR TITLE
Remove unused utility functions.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -79,26 +79,6 @@ function copyObj(obj) {
   return newobj;
 }
 
-// More efficient version of (indexOf o map p)
-var indexOfPred = function(l, p, start) {
-  var start = start || 0;
-  for (var i = start; i < l.length; i++) {
-    if (p(l[i])) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-// more efficient version of (indexOf o map p o reverse)
-var lastIndexOfPred = function(l, p, start) {
-  var start = start || l.length - 1;
-  for (var i = start; i >= 0; i--) {
-    if (p(l[i])) return i;
-  }
-  return -1;
-};
-
 var deleteIndex = function(arr, i) {
   return arr.slice(0, i).concat(arr.slice(i + 1))
 }
@@ -232,10 +212,8 @@ module.exports = {
   expectation: expectation,
   gensym: gensym,
   histsApproximatelyEqual: histsApproximatelyEqual,
-  indexOfPred: indexOfPred,
   logsumexp: logsumexp,
   logHist: logHist,
-  lastIndexOfPred: lastIndexOfPred,
   deleteIndex: deleteIndex,
   makeGensym: makeGensym,
   normalizeArray: normalizeArray,


### PR DESCRIPTION
These were used in `ParticleFilter` prior to #169 but are now unused. I don't expect they'll be used from WebPPL programs, though of course I can't be sure.

The functions `getOpt` and `copyObj` are also unused in the WebPPL code base, but I've not removed those as I'm not sure if they are intended to used internally or in WebPPL programs.

Perhaps we should split out these two kinds of functions at some point.