### PR TITLE
Add sweet.js macros.

### DIFF
--- a/compiled/Makefile
+++ b/compiled/Makefile
@@ -13,7 +13,7 @@ $(MINIFIED): $(BROWSERIFIED)
 	uglifyjs $< -b ascii_only=true,beautify=false > $@
 
 $(BROWSERIFIED): $(SRCFILES)
-	browserify -t brfs $(MAINFILE) > $@
+	browserify -g brfs $(MAINFILE) > $@
 
 clean:
 	rm -f $(MINIFIED) $(BROWSERIFIED)

--- a/docs/analysis/documentation.txt
+++ b/docs/analysis/documentation.txt
@@ -1,6 +1,6 @@
 HOW TO USE IT
 
-The top level of the control-flow analysis is the 'analyze' function in the 'analysis/main' module. This function takes a named, CPS'd AST (which 'prepare' of the 'main' module produces given a literal program) and produces a relation over abstract program states along with some information about the relation itself. All this is encoded as a JS object naming this information. These parts are
+The top level of the control-flow analysis is the 'analyze' function in the 'analysis/main' module. This function takes a named, CPS'd AST (which 'prepare' of the 'analysis/main' module produces given a literal program) and produces a relation over abstract program states along with some information about the relation itself. All this is encoded as a JS object naming this information. These parts are
 
 - 'seen': the set of abstract states over which the relation is defined
 - 'calls': a map from an abstract entry point to a set of abstract call points

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -39,12 +39,12 @@ many of them automatically using::
 To compile webppl for use in browser, run::
 
     npm install -g browserify
-    browserify -t brfs src/browser.js > compiled/webppl.js
+    browserify -g brfs src/browser.js > compiled/webppl.js
 
 Packages can also be used in the browser. For example, to include the
 ``webppl-viz`` package use::
 
-    browserify -t [./src/bundle.js --require webppl-viz] -t brfs src/browser.js > compiled/webppl.js
+    browserify -t [./src/bundle.js --require webppl-viz] -g brfs src/browser.js > compiled/webppl.js
 
 Multiple ``--require`` arguments can be used to include multiple
 packages.

--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -2,7 +2,7 @@ WebPPL Packages
 ===============
 
 WebPPL packages are regular Node.js packages optionally extended to
-include WebPPL code and headers.
+include WebPPL code, macros and headers.
 
 To make a package available in your program use the ``--require``
 argument::
@@ -21,7 +21,7 @@ Packages can be loaded from other locations by passing a path::
 
     webppl myFile.wppl --require ../myPackage
 
-Packages can extend WebPPL in three ways:
+Packages can extend WebPPL in several ways:
 
 WebPPL code
 -----------
@@ -35,6 +35,33 @@ You can automatically prepend WebPPL files to your code by added a
         "wppl": ["myLibrary.wppl"]
       }
     }
+
+Macros
+------
+
+`sweet.js`_ modules can be included in a package as follows:
+
+1. Add a file containing the macros to the package::
+
+    // macros.sjs
+    macro m { /* ... */ }
+    export m;
+
+Note that macros must be exported explicitly using the ``export``
+keyword. See the `sweet.js module documentation`_ for further details.
+
+2. Add a ``macros`` entry to ``package.json``::
+
+    {
+      "name": "my-package",
+      "webppl": {
+        "macros": ["macros.sjs"]
+      }
+    }
+
+These macros will be visible to the WebPPL program which is been run
+or compiled, and to any WebPPL code within the same package. They will
+not be visible to WebPPL code in other packages.
 
 Javascript functions and libraries
 ----------------------------------
@@ -118,3 +145,6 @@ available in WebPPL:
         };
 
         foo();
+
+.. _sweet.js: http://sweetjs.org
+.. _sweet.js module documentation: http://sweetjs.org/doc/main/sweet.html#using-modules

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minimist": "^1.1.1",
     "numeric": "~1.2.6",
     "priorityqueuejs": "~1.0.0",
-    "sweet.js": "null-a/sweet.js#browserify",
+    "sweet.js": "probmods/sweet.js#browserify",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "git-rev-2": "^0.1.0",
     "immutable": "^3.7.1",
     "minimist": "^1.1.1",
-    "priorityqueuejs": "~1.0.0",
     "numeric": "~1.2.6",
+    "priorityqueuejs": "~1.0.0",
+    "sweet.js": "null-a/sweet.js#browserify",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
-    "brfs": "^1.4.0",
+    "brfs": "0.0.8",
     "closure-linter-wrapper": "^0.2.11",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.11.1",

--- a/src/analysis/main.js
+++ b/src/analysis/main.js
@@ -22,6 +22,12 @@ var parse = require('./parser-combinator');
 var analyzeRefs = require('./analyze-refs').analyzeRefs;
 var isHeapRef = require('./analyze-refs').isHeapRef;
 
+var thunkify = require('../syntax').thunkify;
+var naming = require('../transforms/naming').naming;
+var cps = require('../transforms/cps').cps;
+var optimize = require('../transforms/optimize').optimize;
+
+var compile = require('../main').compile;
 
 var isHeapVar = null;
 
@@ -478,6 +484,15 @@ function analyzeMain(program) {
   }
 }
 
+function prepare(code, verbose) {
+  return compile(code, {
+    transforms: [thunkify, naming, cps, optimize],
+    verbose: verbose,
+    generateCode: false
+  });
+}
+
 module.exports = {
-  analyze: analyzeMain
+  analyze: analyzeMain,
+  prepare: prepare
 };

--- a/src/analysis/visualize-run.js
+++ b/src/analysis/visualize-run.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var prepare = require('../main').prepare;
-var analyze = require('../main').analyze;
+var prepare = require('./main').prepare;
+var analyze = require('./main').analyze;
 var vizualize = require('./visualize').vizualize;
 
 process.stdin.setEncoding('utf8');

--- a/src/browser.js
+++ b/src/browser.js
@@ -23,11 +23,13 @@ packages.forEach(function(pkg) {
 });
 
 function run(code, k, verbose) {
-  return webppl.run(code, k, webppl.parsePackageCode(packages), verbose);
+  var extra = webppl.parsePackageCode(packages);
+  return webppl.run(code, k, { extra: extra, verbose: verbose });
 }
 
 function compile(code, verbose) {
-  return webppl.compile(code, webppl.parsePackageCode(packages), verbose);
+  var extra = webppl.parsePackageCode(packages);
+  return webppl.compile(code, { extra: extra, verbose: verbose });
 }
 
 function webpplCPS(code) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -23,12 +23,12 @@ packages.forEach(function(pkg) {
 });
 
 function run(code, k, verbose) {
-  var extra = webppl.parsePackageCode(packages);
+  var extra = webppl.parsePackageCode(packages, verbose);
   return webppl.run(code, k, { extra: extra, verbose: verbose });
 }
 
 function compile(code, verbose) {
-  var extra = webppl.parsePackageCode(packages);
+  var extra = webppl.parsePackageCode(packages, verbose);
   return webppl.compile(code, { extra: extra, verbose: verbose });
 }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,7 +5,7 @@
 var fs = require('fs');
 var esprima = require('esprima');
 var escodegen = require('escodegen');
-
+var _ = require('underscore');
 var webppl = require('./main');
 var optimize = require('./transforms/optimize').optimize;
 var naming = require('./transforms/naming').naming;
@@ -23,14 +23,12 @@ packages.forEach(function(pkg) {
   pkg.headers.forEach(webppl.requireHeaderWrapper);
 });
 
-var wpplExtra = packages.map(function(pkg) { return pkg.wppl.join(';'); }).join(';');
-
 function run(code, k, verbose) {
-  return webppl.run(wpplExtra + code, k, verbose);
+  return webppl.run(code, k, webppl.prepareExtras(packages), verbose);
 }
 
 function compile(code, verbose) {
-  return webppl.compile(wpplExtra + code, verbose);
+  return webppl.compile(code, webppl.prepareExtras(packages), verbose);
 }
 
 function webpplCPS(code) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -24,11 +24,11 @@ packages.forEach(function(pkg) {
 });
 
 function run(code, k, verbose) {
-  return webppl.run(code, k, webppl.prepareExtras(packages), verbose);
+  return webppl.run(code, k, webppl.parsePackageCode(packages), verbose);
 }
 
 function compile(code, verbose) {
-  return webppl.compile(code, webppl.prepareExtras(packages), verbose);
+  return webppl.compile(code, webppl.parsePackageCode(packages), verbose);
 }
 
 function webpplCPS(code) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -5,7 +5,6 @@
 var fs = require('fs');
 var esprima = require('esprima');
 var escodegen = require('escodegen');
-var _ = require('underscore');
 var webppl = require('./main');
 var optimize = require('./transforms/optimize').optimize;
 var naming = require('./transforms/naming').naming;

--- a/src/headerMacros.sjs
+++ b/src/headerMacros.sjs
@@ -1,0 +1,2 @@
+operator (|>) 0 left { $val, $f } => #{ $f($val) }
+export (|>)

--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ function parseExtra(extra) {
 function loadMacros(pkg) {
   return {
     wppl: pkg.wppl,
-    macros: pkg.macros.map(sweet.loadModule)
+    macros: pkg.macros.map(function(code) { return sweet.loadModule(code); })
   };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -160,9 +160,10 @@ function compile(code, options) {
   return util.timeif(options.verbose, 'compile', _compile);
 }
 
-function run(code, k, extra, verbose) {
-  var compiledCode = compile(code, { extra: extra, verbose: verbose });
-  util.timeif(verbose, 'run', function() {
+function run(code, k, options) {
+  var options = options || {};
+  var compiledCode = compile(code, options);
+  util.timeif(options.verbose, 'run', function() {
     eval.call(global, compiledCode)({}, k, '');
   });
 }

--- a/src/pkg.js
+++ b/src/pkg.js
@@ -75,8 +75,8 @@ var load = function(pkg) {
   return {
     js: pkg.js,
     headers: pkg.headers,
-    wppl: pkg.wppl.map(fs.readFileSync),
-    macros: pkg.macros.map(fs.readFileSync)
+    wppl: pkg.wppl.map(function(fn) { return fs.readFileSync(fn); }),
+    macros: pkg.macros.map(function(fn) { return fs.readFileSync(fn); })
   };
 };
 

--- a/src/pkg.js
+++ b/src/pkg.js
@@ -53,7 +53,8 @@ var read = function(name_or_path, paths, verbose) {
           name: name,
           js: isJsModule(candidate) && { identifier: toCamelCase(name), path: candidate },
           headers: _.map(manifest.headers, joinPath),
-          wppl: _.map(manifest.wppl, joinPath)
+          wppl: _.map(manifest.wppl, joinPath),
+          macros: _.map(manifest.macros, joinPath)
         };
       } else {
         return readFirst(candidates.slice(1));
@@ -70,6 +71,15 @@ var read = function(name_or_path, paths, verbose) {
   return log(readFirst(allCandidates))
 };
 
+var load = function(pkg) {
+  return {
+    js: pkg.js,
+    headers: pkg.headers,
+    wppl: pkg.wppl.map(fs.readFileSync),
+    macros: pkg.macros.map(fs.readFileSync)
+  };
+};
+
 var wrapWithQuotes = function(s) { return '"' + s + '"'; };
 var wrapWithRequire = function(s) { return 'require("' + s + '")'; };
 var wrapWithReadFile = function(s) { return 'fs.readFileSync("' + s + '", "utf8")'; };
@@ -79,7 +89,8 @@ var wrappers = {
   name: wrapWithQuotes,
   headers: wrapWithRequire,
   path: wrapWithRequire,
-  wppl: wrapWithReadFile
+  wppl: wrapWithReadFile,
+  macros: wrapWithReadFile
 };
 
 // Recursively transform a package (as returned by read) into an expression
@@ -100,6 +111,7 @@ var stringify = function(obj, lastSeenKey) {
 
 module.exports = {
   read: read,
+  load: load,
   stringify: stringify,
   globalPkgDir: globalPkgDir
 };

--- a/src/transforms/caching.js
+++ b/src/transforms/caching.js
@@ -2,11 +2,12 @@
 
 var _ = require('underscore');
 
-var Syntax = require('estraverse').Syntax;
-var replace = require('estraverse').replace;
+var estraverse = require('estraverse');
 var build = require('ast-types').builders;
 var types = require('ast-types').types;
 var isPrimitive = require('../syntax').isPrimitive;
+
+var Syntax = estraverse.Syntax;
 
 var cacheExempt = [
   'flip',
@@ -63,9 +64,23 @@ function exit(node) {
 }
 
 function cachingMain(node) {
-  return replace(node, { leave: exit });
+  return estraverse.replace(node, { leave: exit });
+}
+
+function transformRequired(programAST) {
+  var flag = false;
+  estraverse.traverse(programAST, {
+    enter: function(node) {
+      if (node.type === 'Identifier' && node.name === 'IncrementalMH') {
+        flag = true;
+        this.break();
+      }
+    }
+  });
+  return flag;
 }
 
 module.exports = {
-  caching: cachingMain
+  transform: cachingMain,
+  transformRequired: transformRequired
 };

--- a/src/util.js
+++ b/src/util.js
@@ -209,6 +209,25 @@ function deserialize(o) {
   return JSON.parse(o, InfFromJSON);
 }
 
+function time(name, thunk) {
+  if (console.time) {
+    console.time(name);
+    var ret = thunk();
+    console.timeEnd(name);
+    return ret;
+  } else {
+    return thunk();
+  }
+}
+
+function timeif(bool, name, thunk) {
+  return bool ? time(name, thunk) : thunk();
+}
+
+function pipeline(fns) {
+  return _.compose.apply(null, fns.reverse());
+}
+
 module.exports = {
   random: random,
   seedRNG: seedRNG,
@@ -233,5 +252,7 @@ module.exports = {
   sum: sum,
   asArray: asArray,
   serialize: serialize,
-  deserialize: deserialize
+  deserialize: deserialize,
+  timeif: timeif,
+  pipeline: pipeline
 };

--- a/tests/test-analysis.js
+++ b/tests/test-analysis.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var prepare = require('../src/main').prepare;
-var analyze = require('../src/analysis/main').analyze;
+var analysis = require('../src/analysis/main');
 
 var Set = require('immutable').Set;
 
@@ -29,7 +28,7 @@ var tests = {
 
 function makeTest(t) {
   return function(test) {
-    var results = analyze(prepare(t.program));
+    var results = analysis.analyze(analysis.prepare(t.program));
 
     var values = results.finals.reduce(function(values, result) {
       return values.union(result.value);

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var webppl = require('../src/main');
+
+var pkg1 = {
+  wppl: ['var inc = function(x) { x + 1 };' +
+         'var fnWithMacro = function() { return m1; };' +
+         'var fnWithHeaderMacro = function() { 1 |> inc };'],
+  macros: ["macro m1 { rule {} => { 'macro' } }; export m1;"]
+};
+
+var pkg2 = {
+  wppl: ['var fnWithPkg1Macro = function() { m1 };' +
+         'var fnWithPkg2Macro = function() { m2 };'],
+  macros: ["macro m2 { rule {} => { 'macro2' } }; export m2;"]
+};
+
+var wpplRunWithPkgs = function(code, packages) {
+  var val;
+  var extras = webppl.prepareExtras(packages);
+  webppl.run(code, function(s, v) { val = v; }, extras);
+  return val;
+};
+
+module.exports = {
+  testPkgMacrosAppliedToProgram: function(test) {
+    test.strictEqual('macro', wpplRunWithPkgs('m1', [pkg1]));
+    test.done();
+  },
+  testPkgMacrosAppliedToPkg: function(test) {
+    test.strictEqual('macro', wpplRunWithPkgs('fnWithMacro()', [pkg1]));
+    test.done();
+  },
+  testHeaderMacrosAppliedToPkg: function(test) {
+    test.strictEqual(2, wpplRunWithPkgs('fnWithHeaderMacro()', [pkg1]));
+    test.done();
+  },
+  testPkgMacrosNotAppliedToOtherPkg: function(test) {
+    test.strictEqual('macro2', wpplRunWithPkgs('fnWithPkg2Macro()', [pkg1, pkg2]));
+    test.throws(function() {
+      wpplRunWithPkgs('fnWithPkg1Macro()', [pkg1, pkg2]);
+    }, /m1 is not defined/);
+    test.done();
+  }
+};

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -17,8 +17,8 @@ var pkg2 = {
 
 var wpplRunWithPkgs = function(code, packages) {
   var val;
-  var extras = webppl.prepareExtras(packages);
-  webppl.run(code, function(s, v) { val = v; }, extras);
+  var extra = webppl.parsePackageCode(packages);
+  webppl.run(code, function(s, v) { val = v; }, extra);
   return val;
 };
 

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -18,7 +18,7 @@ var pkg2 = {
 var wpplRunWithPkgs = function(code, packages) {
   var val;
   var extra = webppl.parsePackageCode(packages);
-  webppl.run(code, function(s, v) { val = v; }, extra);
+  webppl.run(code, function(s, v) { val = v; }, { extra: extra });
   return val;
 };
 

--- a/webppl
+++ b/webppl
@@ -30,7 +30,7 @@ function run(code, packages, verbose) {
         console.log('\n* Program return value:\n');
         printWebPPLValue(x);
       },
-      webppl.prepareExtras(packages),
+      webppl.parsePackageCode(packages),
       verbose);
 }
 
@@ -43,14 +43,14 @@ function compile(code, packages, verbose, outputFile) {
     });
   });
 
-  var extras = webppl.prepareExtras(packages);
+  var extra = webppl.parsePackageCode(packages);
 
   compiledCode += (
       printWebPPLValue.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +
       ' printWebPPLValue(x); \n};\n\n');
-  compiledCode += 'var main = ' + webppl.compile(code, extras, verbose) + '\n\n';
+  compiledCode += 'var main = ' + webppl.compile(code, extra, verbose) + '\n\n';
   compiledCode += "main({}, topK, '');";
   // Write Javascript code to file
   fs.writeFile(

--- a/webppl
+++ b/webppl
@@ -30,8 +30,10 @@ function run(code, packages, verbose) {
         console.log('\n* Program return value:\n');
         printWebPPLValue(x);
       },
-      webppl.parsePackageCode(packages),
-      verbose);
+      {
+        extra: webppl.parsePackageCode(packages),
+        verbose: verbose
+      });
 }
 
 function compile(code, packages, verbose, outputFile) {
@@ -43,14 +45,14 @@ function compile(code, packages, verbose, outputFile) {
     });
   });
 
-  var extra = webppl.parsePackageCode(packages);
+  var compileOptions = { extra: webppl.parsePackageCode(packages), verbose: verbose };
 
   compiledCode += (
       printWebPPLValue.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +
       ' printWebPPLValue(x); \n};\n\n');
-  compiledCode += 'var main = ' + webppl.compile(code, extra, verbose) + '\n\n';
+  compiledCode += 'var main = ' + webppl.compile(code, compileOptions) + '\n\n';
   compiledCode += "main({}, topK, '');";
   // Write Javascript code to file
   fs.writeFile(

--- a/webppl
+++ b/webppl
@@ -31,7 +31,7 @@ function run(code, packages, verbose) {
         printWebPPLValue(x);
       },
       {
-        extra: webppl.parsePackageCode(packages),
+        extra: webppl.parsePackageCode(packages, verbose),
         verbose: verbose
       });
 }
@@ -45,7 +45,7 @@ function compile(code, packages, verbose, outputFile) {
     });
   });
 
-  var compileOptions = { extra: webppl.parsePackageCode(packages), verbose: verbose };
+  var compileOptions = { extra: webppl.parsePackageCode(packages, verbose), verbose: verbose };
 
   compiledCode += (
       printWebPPLValue.toString() + '\n' +

--- a/webppl
+++ b/webppl
@@ -22,10 +22,6 @@ function run(code, packages, verbose) {
   packages.forEach(function(pkg) {
     if (pkg.js) { global[pkg.js.identifier] = require(pkg.js.path); }
     pkg.headers.forEach(webppl.requireHeader);
-    pkg.wppl.forEach(function(fn) {
-      var wppl = fs.readFileSync(fn, 'utf8');
-      code = wppl + ';' + code;
-    });
   });
 
   webppl.run(
@@ -34,6 +30,7 @@ function run(code, packages, verbose) {
         console.log('\n* Program return value:\n');
         printWebPPLValue(x);
       },
+      webppl.prepareExtras(packages),
       verbose);
 }
 
@@ -44,18 +41,16 @@ function compile(code, packages, verbose, outputFile) {
     pkg.headers.forEach(function(header) {
       compiledCode += 'webppl.requireHeader("' + header + '");\n';
     });
-    pkg.wppl.forEach(function(fn) {
-      var wppl = fs.readFileSync(fn, 'utf8');
-      code = wppl + ';' + code;
-    });
   });
+
+  var extras = webppl.prepareExtras(packages);
 
   compiledCode += (
       printWebPPLValue.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +
       ' printWebPPLValue(x); \n};\n\n');
-  compiledCode += 'var main = ' + webppl.compile(code, verbose) + '\n\n';
+  compiledCode += 'var main = ' + webppl.compile(code, extras, verbose) + '\n\n';
   compiledCode += "main({}, topK, '');";
   // Write Javascript code to file
   fs.writeFile(
@@ -111,9 +106,8 @@ function main() {
   ];
 
   var packages = util.asArray(argv.require).map(function(name_or_path) {
-    return pkg.read(name_or_path, packagePaths, argv.verbose)
+    return pkg.load(pkg.read(name_or_path, packagePaths, argv.verbose));
   });
-
 
   var seed = argv['random-seed'];
   if (seed !== undefined) {


### PR DESCRIPTION
This is a cleaned up version of the macros branch we've been discussing in #153. I don't have any more changes planned so this is ready to be reviewed.

I'm still using an old version of brfs and a patched version of sweet.js in order to get `browserify` working.

Getting brfs updated is more involved than I'd hoped, it's certainly not a trivial bug-fix. I've opened an issue to try and find out whether a PR making the change we need is likely to be accepted, but I've not heard back yet. Perhaps we're best merging this as is so we can see if we're happy with our approach before putting lots of effort into updating brfs and sweet.js?

Perhaps the fork of sweet.js should live under the probmods account?

This also closes #209.