### PR TITLE
Add basic browser tests.

### DIFF
--- a/compiled/Makefile
+++ b/compiled/Makefile
@@ -6,6 +6,7 @@ SRCFILES = $(wildcard ../src/*.js) \
 MAINFILE = ../src/browser.js
 MINIFIED = webppl.min.js
 BROWSERIFIED = webppl.js
+TESTS = ../tests/browser/index.html
 
 all: $(MINIFIED)
 
@@ -14,6 +15,9 @@ $(MINIFIED): $(BROWSERIFIED)
 
 $(BROWSERIFIED): $(SRCFILES)
 	browserify -t brfs $(MAINFILE) > $@
+
+test: $(BROWSERIFIED)
+	node -e "require('open')(process.argv[1], process.env.BROWSER)" $(TESTS)
 
 clean:
 	rm -f $(MINIFIED) $(BROWSERIFIED)

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -38,8 +38,19 @@ many of them automatically using::
 
 To compile webppl for use in browser, run::
 
-    npm install -g browserify
-    browserify -t brfs src/browser.js > compiled/webppl.js
+    npm install -g browserify uglifyjs
+    cd compiled
+    make clean
+    make
+
+Then, to run the browser tests use::
+
+    make test
+
+The tests will run in the default browser. Specify a different browser
+using the ``BROWSER`` environment variable. For example::
+
+    BROWSER="Google Chrome" make test
 
 Packages can also be used in the browser. For example, to include the
 ``webppl-viz`` package use::

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-gjslint": "^0.1.6",
     "nodeunit": "^0.9.1",
+    "open": "0.0.5",
     "seedrandom": "^2.4.2",
     "through2": "^2.0.0"
   },

--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>WebPPL</title>
+    <script src="../../compiled/webppl.js"></script>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.19.0.css">
+  </head>
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
+    <script src="tests.js"></script>
+  </body>
+</html>

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -1,0 +1,23 @@
+'use strict';
+
+QUnit.test('run', function(test) {
+  webppl.run('Enumerate(flip)', function(s, erp) {
+    test.ok(_.isEqual([false, true], erp.support().sort()));
+  });
+});
+
+QUnit.test('compile', function(test) {
+  test.ok(_.isString(webppl.compile('1 + 1')));
+});
+
+QUnit.test('cps', function(test) {
+  var code = webppl.cps('100');
+  eval(code)(function(val) {
+    test.strictEqual(100, val);
+  });
+});
+
+QUnit.test('naming', function(test) {
+  var code = webppl.naming('100');
+  test.strictEqual(100, eval(code)());
+});


### PR DESCRIPTION
This makes it straight-forward to run a few very basic browser tests. These are intentionally *very* simple and are only intended to ensure that `broswerify` has worked and that the methods we expose via `webppl` exist and work for simple cases.

It's also serves as a quick way to build WebPPL and load it into a browser so things can be tried out at the console.

Something like this was useful while working on macros. It might also be useful when updating dippl.org. (#238)

To use it do:

````
make clean
make test
````

You can specify which browser the tests should be run in like so:

````
BROWSER="Google Chrome" make test
````