### PR TITLE
Run tests against latest version of node v4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-  - "4.0.0"
+  - "4"
 
 install:
   - npm install


### PR DESCRIPTION
I noticed you can specify just the major revision to have tests run against the latest node release. (4.1.2 at present.) This seems useful as we only need to worry about adding any minor revisions we'd like to continue testing against after they've been superseded, rather then having to update `travis.yml` every time a new version is released.