### PR TITLE
Support 'no caching' directive in header files

### DIFF
--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -36,6 +36,18 @@ You can automatically prepend WebPPL files to your code by added a
       }
     }
 
+The use of some inference algorithms causes a caching transform to be
+applied to each ``wppl`` file. It is possible to skip the application
+of this transform on a per-file basis by placing the ``no caching``
+directive at the beginning of the file. For example::
+
+    'no caching';
+
+    // Rest of WebPPL program
+
+This is expected to be useful in only a limited number of cases and
+shouldn't be applied routinely.
+
 Macros
 ------
 

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -1,3 +1,5 @@
+'no caching';
+
 // ERPs
 
 var flip = function(theta) {

--- a/src/main.js
+++ b/src/main.js
@@ -123,9 +123,8 @@ function parsePackageCode(packages, verbose) {
 }
 
 function applyCaching(asts) {
-  // This assume that asts[0] is the header.
-  return asts.map(function(ast, i) {
-    return i > 0 ? caching.transform(ast) : ast;
+  return asts.map(function(ast) {
+    return caching.hasNoCachingDirective(ast) ? ast : caching.transform(ast);
   });
 }
 

--- a/src/transforms/caching.js
+++ b/src/transforms/caching.js
@@ -80,7 +80,15 @@ function transformRequired(programAST) {
   return flag;
 }
 
+function hasNoCachingDirective(ast) {
+  return ast.body.length > 0 &&
+         ast.body[0].type === Syntax.ExpressionStatement &&
+         ast.body[0].expression.type === Syntax.Literal &&
+         ast.body[0].expression.value === 'no caching';
+}
+
 module.exports = {
   transform: cachingMain,
-  transformRequired: transformRequired
+  transformRequired: transformRequired,
+  hasNoCachingDirective: hasNoCachingDirective
 };

--- a/tests/test-caching.js
+++ b/tests/test-caching.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var _ = require('underscore');
+var parse = require('esprima').parse;
+var caching = require('../src/transforms/caching');
+
+var hasCachingDirectiveTests = {
+  test1: { code: "'no caching'", expected: true },
+  test2: { code: '"no caching";\n', expected: true },
+  test3: { code: '\n"no caching";\n1+1', expected: true },
+  test4: { code: '1 + 1', expected: false },
+  test5: { code: "1 + 1;\n'no caching'", expected: false },
+  test6: { code: '', expected: false }
+};
+
+var transformRequiredTests = {
+  test1: { code: 'IncrementalMH(model, 0);', expected: true },
+  test2: { code: 'Enumerate(model);', expected: false }
+};
+
+function generateTests(cases, testFn) {
+  return _.mapObject(cases, function(caseDef) {
+    return function(test) {
+      test.strictEqual(testFn(parse(caseDef.code)), caseDef.expected);
+      test.done();
+    };
+  });
+}
+
+module.exports = {
+  hasNoCachingDirective: generateTests(hasCachingDirectiveTests, caching.hasNoCachingDirective),
+  transformRequired: generateTests(transformRequiredTests, caching.transformRequired)
+};


### PR DESCRIPTION
This adds support for a `no caching` directive which allows header files to opt out of the caching transform. It was mentioned [here](https://github.com/probmods/webppl/issues/202#issuecomment-148183395) that we might want to merge this.