### PR TITLE
Run browser tests in phantomjs on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,23 @@ node_js:
   - "4"
   - "5"
 
+env:
+  - TASK=default
+
+matrix:
+  include:
+    - node_js: "5"
+      env: TASK=travis-phantomjs
+
 install:
   - npm install
   - npm install -g nodeunit grunt-cli
+  - if [ $TASK = travis-phantomjs ]; then npm install -g browserify uglifyjs; fi
+  - if [ $TASK = travis-phantomjs ]; then travis/install-phantomjs.sh; fi
+  - if [ $TASK = travis-phantomjs ]; then export PATH=$PWD/phantomjs:$PATH; fi
 
 script:
-  - grunt
+  - grunt $TASK
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ install:
   - npm install
   - npm install -g nodeunit grunt-cli
   - if [ $TASK = travis-phantomjs ]; then npm install -g browserify uglifyjs; fi
-  - if [ $TASK = travis-phantomjs ]; then travis/install-phantomjs.sh; fi
-  - if [ $TASK = travis-phantomjs ]; then export PATH=$PWD/phantomjs:$PATH; fi
 
 script:
   - grunt $TASK
 
-sudo: false
+sudo: required
+dist: trusty
 
 notifications:
   slack: cocolab-stanford:X2Ebs0qIMVUidJBD1xZd2XU1

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,7 @@ module.exports = function(grunt) {
   grunt.registerTask('lint', ['gjslint']);
   grunt.registerTask('hint', ['jshint']);
   grunt.registerTask('fixstyle', ['fixjsstyle']);
+  grunt.registerTask('travis-phantomjs', ['compile', 'test-phantomjs']);
 
   grunt.registerTask('compile', 'Compile for the browser', function() {
     var pkgArg = '';
@@ -94,5 +95,15 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test-browser', function() {
     open('tests/browser/index.html', process.env.BROWSER);
+  });
+
+  grunt.registerTask('test-phantomjs', function() {
+    try {
+      var output = execSync('phantomjs node_modules/qunit-phantomjs-runner/runner-list.js tests/browser/index.html');
+      grunt.log.writeln(output);
+    } catch (e) {
+      grunt.log.writeln(e.output.join('\n'));
+      throw e;
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-gjslint": "^0.2.0",
     "nodeunit": "^0.9.1",
     "open": "0.0.5",
+    "qunit-phantomjs-runner": "^2.1.0",
     "through2": "^2.0.0"
   },
   "scripts": {

--- a/travis/install-phantomjs.sh
+++ b/travis/install-phantomjs.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -ex
-wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-mkdir phantomjs
-tar xvf phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C phantomjs

--- a/travis/install-phantomjs.sh
+++ b/travis/install-phantomjs.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -ex
+wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+mkdir phantomjs
+tar xvf phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C phantomjs


### PR DESCRIPTION
This PR:

* Adds a new task `grunt test-phantomjs` which runs our (very simple) browser tests in phantomjs.
* Adds the config required to run this task on Travis.

The Travis VMs include v1.9.8 of phantomjs but WebPPL and the tests won't run under that, hence the manual install of v2.0.0.

We could get a lot of the benefit of this set-up (e.g. ensuring `grunt compile` works) by simply `require`ing `webppl.min.js` in node and running the tests from there. Maybe we should keep that in mind in case maintaining this phantomjs set-up becomes painful.

Closes #243.