### PR TITLE
Updates to expectation and std util funcs.

### DIFF
--- a/src/erp.js
+++ b/src/erp.js
@@ -620,6 +620,7 @@ function makeMarginalERP(marginal) {
   });
 
   dist.MAP = function() {return mapEst};
+  dist.hist = marginal;
   return dist;
 }
 

--- a/src/inference/mh-diagnostics/diagnostics.js
+++ b/src/inference/mh-diagnostics/diagnostics.js
@@ -1,4 +1,4 @@
-var util = require('../../util');
+var stats = require('../../statistics');
 var fs = require('fs');
 var os = require('os');
 
@@ -15,8 +15,8 @@ function geweke(traces, first, last, intervals) {
   for (var i = 0; i < traces.length / 2; i = i + Math.floor((traces.length / 2) / (intervals - 1))) {
     var firstSlice = traces.slice(i, i + Math.floor(first * (end - i)));
     var lastSlice = traces.slice(Math.floor(end - last * (end - i)), traces.length);
-    var mu = (util.mean(firstSlice) - util.mean(lastSlice));
-    var zscore = mu / Math.sqrt(Math.pow(util.std(firstSlice), 2) + Math.pow(util.std(lastSlice), 2));
+    var mu = (stats.mean(firstSlice) - stats.mean(lastSlice));
+    var zscore = mu / Math.sqrt(stats.variance(firstSlice) + stats.variance(lastSlice));
     zscores.push([i, zscore]);
   }
   return zscores;

--- a/src/util.js
+++ b/src/util.js
@@ -134,22 +134,6 @@ function cpsIterate(n, initial, func, cont) {
       function() { return cont(val); });
 }
 
-function expectation(a, func) {
-  assert.ok(a.length > 0);
-  var f = func || _.identity;
-  return _.reduce(a, function(acc, x) {
-    return acc + f(x);
-  }, 0) / a.length;
-}
-
-function std(a, mean) {
-  assert.ok(a.length > 0);
-  var m = (mean !== undefined) ? mean : expectation(a);
-  return Math.sqrt(expectation(a, function(x) {
-    return Math.pow(x - m, 2);
-  }));
-}
-
 function histExpectation(hist, func) {
   var f = func || _.identity;
   return _.reduce(hist, function(acc, obj) {
@@ -246,8 +230,6 @@ module.exports = {
   cpsForEach: cpsForEach,
   cpsLoop: cpsLoop,
   cpsIterate: cpsIterate,
-  expectation: expectation,
-  std: std,
   histExpectation: histExpectation,
   histStd: histStd,
   histsApproximatelyEqual: histsApproximatelyEqual,

--- a/src/util.js
+++ b/src/util.js
@@ -152,10 +152,8 @@ function std(a, mean) {
 
 function histExpectation(hist, func) {
   var f = func || _.identity;
-  return _.reduce(hist, function(acc, pair) {
-    var x = pair[0];
-    var p = pair[1];
-    return acc + p * f(x);
+  return _.reduce(hist, function(acc, obj) {
+    return acc + obj.prob * f(obj.val);
   }, 0);
 }
 
@@ -167,7 +165,7 @@ function histStd(hist) {
 }
 
 function histsApproximatelyEqual(actualHist, expectedHist, tolerance) {
-  var hist = _.object(_.map(actualHist, function(p) { return [serialize(p[0]), p[1]]; }));
+  var hist = _.mapObject(actualHist, function(obj) { return obj.prob; });
   var allOk = (expectedHist !== undefined);
   _.each(
       expectedHist,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -305,7 +305,6 @@ var wpplRunInference = function(modelName, testDef) {
 
 var performTest = function(modelName, testDef, test) {
   var result = wpplRunInference(modelName, testDef);
-  result.hist = getHist(result.erp);
   var expectedResults = helpers.loadExpected(testDataDir, modelName);
 
   _.each(expectedResults, function(expected, testName) {
@@ -330,13 +329,13 @@ var getInferenceArgs = function(testDef, model) {
 
 var testFunctions = {
   hist: function(test, result, expected, args) {
-    test.ok(util.histsApproximatelyEqual(result.hist, expected, args.tol));
+    test.ok(util.histsApproximatelyEqual(result.erp.hist, expected, args.tol));
   },
   mean: function(test, result, expected, args) {
-    helpers.testWithinTolerance(test, util.histExpectation(result.hist), expected, args.tol, 'mean');
+    helpers.testWithinTolerance(test, util.histExpectation(result.erp.hist), expected, args.tol, 'mean');
   },
   std: function(test, result, expected, args) {
-    helpers.testWithinTolerance(test, util.histStd(result.hist), expected, args.tol, 'std');
+    helpers.testWithinTolerance(test, util.histStd(result.erp.hist), expected, args.tol, 'std');
   },
   logZ: function(test, result, expected, args) {
     if (args.check) {
@@ -353,14 +352,6 @@ var testFunctions = {
   store: function(test, result, expected, args) {
     helpers.testEqual(test, result.store, expected, 'store');
   }
-};
-
-var getHist = function(erp) {
-  var hist = [];
-  erp.support().forEach(function(value) {
-    hist.push([value, Math.exp(erp.score([], value))]);
-  });
-  return hist;
 };
 
 var generateTestCases = function(seed) {

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -333,10 +333,10 @@ var testFunctions = {
     test.ok(util.histsApproximatelyEqual(result.hist, expected, args.tol));
   },
   mean: function(test, result, expected, args) {
-    helpers.testWithinTolerance(test, util.expectation(result.hist), expected, args.tol, 'mean');
+    helpers.testWithinTolerance(test, util.histExpectation(result.hist), expected, args.tol, 'mean');
   },
   std: function(test, result, expected, args) {
-    helpers.testWithinTolerance(test, util.std(result.hist), expected, args.tol, 'std');
+    helpers.testWithinTolerance(test, util.histStd(result.hist), expected, args.tol, 'std');
   },
   logZ: function(test, result, expected, args) {
     if (args.check) {
@@ -356,11 +356,11 @@ var testFunctions = {
 };
 
 var getHist = function(erp) {
-  var hist = {};
+  var hist = [];
   erp.support().forEach(function(value) {
-    hist[util.serialize(value)] = Math.exp(erp.score([], value));
+    hist.push([value, Math.exp(erp.score([], value))]);
   });
-  return util.normalizeHist(hist);
+  return hist;
 };
 
 var generateTestCases = function(seed) {

--- a/tests/test-statistics.js
+++ b/tests/test-statistics.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var stats = require('../src/statistics');
+
+module.exports = {
+
+  testMean: {
+
+    test1: function(test) {
+      test.strictEqual(stats.mean([0, 3, 9]), 4);
+      test.done();
+    },
+    test2: function(test) {
+      test.strictEqual(stats.mean(new Float64Array([0, 3, 9])), 4);
+      test.done();
+    },
+    test3: function(test) {
+      test.throws(function() { stats.mean([]); });
+      test.done();
+    }
+
+  },
+
+  testStandardDeviation: {
+
+    test1: function(test) {
+      test.strictEqual(stats.sd([0, 1, 2]), Math.sqrt(2 / 3));
+      test.done();
+    },
+    test2: function(test) {
+      test.strictEqual(stats.sd(new Float64Array([0, 1, 2])), Math.sqrt(2 / 3));
+      test.done();
+    },
+    test3: function(test) {
+      test.throws(function() { stats.sd([]); });
+      test.done();
+    }
+
+  }
+
+};

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -44,40 +44,6 @@ module.exports = {
       test.done();
     }
 
-  },
-
-  testExpectation: {
-
-    test1: function(test) {
-      test.strictEqual(util.expectation([0, 3, 9]), 4);
-      test.done();
-    },
-    test2: function(test) {
-      test.strictEqual(util.expectation(new Float64Array([0, 3, 9])), 4);
-      test.done();
-    },
-    test3: function(test) {
-      test.throws(function() { util.expectation([]); });
-      test.done();
-    }
-
-  },
-
-  testStd: {
-
-    test1: function(test) {
-      test.strictEqual(util.std([0, 1, 2]), Math.sqrt(2 / 3));
-      test.done();
-    },
-    test2: function(test) {
-      test.strictEqual(util.std([0, 2, 4], 2), Math.sqrt(8 / 3));
-      test.done();
-    },
-    test3: function(test) {
-      test.throws(function() { util.std([]); });
-      test.done();
-    }
-
   }
 
 };

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -44,6 +44,40 @@ module.exports = {
       test.done();
     }
 
+  },
+
+  testExpectation: {
+
+    test1: function(test) {
+      test.strictEqual(util.expectation([0, 3, 9]), 4);
+      test.done();
+    },
+    test2: function(test) {
+      test.strictEqual(util.expectation(new Float64Array([0, 3, 9])), 4);
+      test.done();
+    },
+    test3: function(test) {
+      test.throws(function() { util.expectation([]); });
+      test.done();
+    }
+
+  },
+
+  testStd: {
+
+    test1: function(test) {
+      test.strictEqual(util.std([0, 1, 2]), Math.sqrt(2 / 3));
+      test.done();
+    },
+    test2: function(test) {
+      test.strictEqual(util.std([0, 2, 4], 2), Math.sqrt(8 / 3));
+      test.done();
+    },
+    test3: function(test) {
+      test.throws(function() { util.std([]); });
+      test.done();
+    }
+
   }
 
 };


### PR DESCRIPTION
The motivation for this change is the desire to be able to use `util.expectation` in #277. The main things in the way of that are the fact that `expectation` ignores its `func` arg when operating on an arrays and it won't work with `Float64Array`s. Both of those are fixed here. I've also made a few other tweaks while I was doing this.

* hists in inference tests are now represented as lists of pairs to avoid doing arithmetic
  with the keys of objects which are strings not numbers.
* Remove unnecessary normalizeHist from `test-inference.js`. (Marginals are already normalized.)