### PR TITLE
Deep copy AST in compile

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -22,13 +22,13 @@ packages.forEach(function(pkg) {
   pkg.headers.forEach(webppl.requireHeaderWrapper);
 });
 
+var extra = webppl.parsePackageCode(packages);
+
 function run(code, k, verbose) {
-  var extra = webppl.parsePackageCode(packages, verbose);
   return webppl.run(code, k, { extra: extra, verbose: verbose });
 }
 
 function compile(code, verbose) {
-  var extra = webppl.parsePackageCode(packages, verbose);
   return webppl.compile(code, { extra: extra, verbose: verbose });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -128,6 +128,14 @@ function applyCaching(asts) {
   });
 }
 
+function copyAst(ast) {
+  var ret = _.isArray(ast) ? [] : {};
+  _.each(ast, function(val, key) {
+    ret[key] = _.isObject(val) ? copyAst(val) : val;
+  });
+  return ret;
+}
+
 function compile(code, options) {
   var options = util.mergeDefaults(options, { verbose: false, generateCode: true });
 
@@ -144,7 +152,7 @@ function compile(code, options) {
 
   function _compile() {
     var programAst = parse(code, extra.macros);
-    var asts = extra.asts.concat(programAst);
+    var asts = extra.asts.map(copyAst).concat(programAst);
     var doCaching = _.any(asts, caching.transformRequired);
 
     if (options.verbose && doCaching) {

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -6,6 +6,14 @@ QUnit.test('run', function(test) {
   });
 });
 
+QUnit.test('run twice', function(test) {
+  _.times(2, function() {
+    webppl.run('Enumerate(flip)', function(s, erp) {
+      test.ok(_.isEqual([false, true], erp.support().sort()));
+    });
+  });
+});
+
 QUnit.test('compile', function(test) {
   test.ok(_.isString(webppl.compile('1 + 1')));
 });


### PR DESCRIPTION
At present, `compile` mutates package ASTs. (#247) This fixes that by having `compile` copy the ASTs before performing any transforms. I [tried this approach before](https://github.com/probmods/webppl/pull/241#issuecomment-147342288) but found it to be too slow. I realised it can be made to work by writing a simpler deep copy than the fancy one in lodash which I used originally.

With this in place, it's now possible to call `parsePackageCode` once on page load, rather than in every call to `run` and `compile` in the browser. (This PR includes that change too.) Hopefully this will make running code boxes feel a bit snappier. Rough before and after timings are something like:

Before

````
1st run:
parsePackageCode: 700ms
compile: 300ms

Subsequent runs:
parsePackageCode: 200ms
compile: 200ms
````

After:

````
Page load:
parsePackageCode: 700ms

1st run:
compile: 320ms

Subsequent runs:
compile: 200ms
````

So, for all but the first run, the amount of time it takes before the program starts running drops from around 400ms to 200ms with this change. (Ignoring any other steps, non of which I think take much time.) The win might be bigger with extra packages added to the browser bundle.

As things stand, the package/header ASTs are copied when running under Node, even though `compile` is only ever called once there. We could add an option to `compile` to avoid doing this, but copying the header AST only takes about 10ms so I wasn't convinced it was worth the extra complexity. Of course, I'm happy to change this if people think that would be better.