### PR TITLE
Use Histogram everywhere

### DIFF
--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -13,17 +13,17 @@ Histogram.prototype.add = function(value) {
   var value = untapify(value);
   var k = util.serialize(value);
   if (this.hist[k] === undefined) {
-    this.hist[k] = { prob: 0, val: value };
+    this.hist[k] = { count: 0, val: value };
   }
-  this.hist[k].prob += 1;
+  this.hist[k].count += 1;
 };
 
 function normalizeHist(hist) {
-  var norm = _.reduce(hist, function(acc, obj) {
-    return acc + obj.prob;
+  var totalCount = _.reduce(hist, function(acc, obj) {
+    return acc + obj.count;
   }, 0);
   return _.mapObject(hist, function(obj) {
-    return { val: obj.val, prob: obj.prob / norm };
+    return { val: obj.val, prob: obj.count / totalCount };
   });
 }
 
@@ -38,18 +38,18 @@ var Distribution = function() {
 Distribution.prototype.add = function(value, score) {
   var k = util.serialize(value);
   if (this.dist[k] === undefined) {
-    this.dist[k] = { prob: -Infinity, val: value };
+    this.dist[k] = { score: -Infinity, val: value };
   }
-  this.dist[k].prob = util.logsumexp([this.dist[k].prob, score]);
+  this.dist[k].score = util.logsumexp([this.dist[k].score, score]);
 };
 
 function normalizeDist(dist) {
   // Note, this also maps dist from log space into probability space.
   var logNorm = _.reduce(dist, function(acc, obj) {
-    return util.logsumexp([acc, obj.prob]);
+    return util.logsumexp([acc, obj.score]);
   }, -Infinity);
   return _.mapObject(dist, function(obj) {
-    return { val: obj.val, prob: Math.exp(obj.prob - logNorm) };
+    return { val: obj.val, prob: Math.exp(obj.score - logNorm) };
   });
 }
 

--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -22,6 +22,22 @@ Histogram.prototype.toERP = function() {
   return erp.makeMarginalERP(util.logHist(this.hist));
 };
 
+var Distribution = function() {
+  this.dist = {};
+};
+
+Distribution.prototype.add = function(value, score) {
+  var k = util.serialize(value);
+  if (this.dist[k] === undefined) {
+    this.dist[k] = { prob: -Infinity, val: value };
+  }
+  this.dist[k].prob = util.logsumexp([this.dist[k].prob, score]);
+};
+
+Distribution.prototype.toERP = function() {
+  return erp.makeMarginalERP(this.dist);
+};
+
 var MAP = function(retainSamples) {
   this.max = { value: undefined, score: -Infinity };
   this.samples = [];
@@ -61,5 +77,6 @@ function untapify(x) {
 
 module.exports = {
   Histogram: Histogram,
+  Distribution: Distribution,
   MAP: MAP
 };

--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -47,7 +47,7 @@ var MAP = function(retainSamples) {
 MAP.prototype.add = function(value, score) {
   var value = untapify(value);
   if (this.retainSamples) {
-    this.samples.push(value);
+    this.samples.push({ value: value, score: score });
   }
   if (score > this.max.score) {
     this.max.value = value;

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -610,24 +610,12 @@ function multinomialSample(theta) {
   return k - 1;
 }
 
-// Make a discrete ERP from a {val: prob, etc.} object (unormalized).
+// Make a discrete ERP from a normalized {val: ..., prob: ...} object.
 function makeMarginalERP(marginal) {
   assert.ok(_.size(marginal) > 0);
-  // Normalize distribution:
-  var norm = -Infinity;
-  var supp = [];
-  for (var v in marginal) {if (marginal.hasOwnProperty(v)) {
-    var d = marginal[v];
-    norm = util.logsumexp([norm, d.prob]);
-    supp.push(d.val);
-  }}
-  for (v in marginal) {if (marginal.hasOwnProperty(v)) {
-    var dd = marginal[v];
-    var nprob = dd.prob - norm;
-    var nprobS = Math.exp(nprob)
-    marginal[v].prob = nprobS;
-  }}
-
+  var supp = _.map(marginal, function(obj) {
+    return obj.val;
+  });
   // Make an ERP from marginal:
   var dist = new ERP({
     sample: function(params) {

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -613,11 +613,11 @@ function multinomialSample(theta) {
 // Make a discrete ERP from a normalized {val: ..., prob: ...} object.
 function makeMarginalERP(marginal) {
   assert.ok(_.size(marginal) > 0);
-  var supp = _.map(marginal, function(obj) {
+  var support = _.map(marginal, function(obj) {
     return obj.val;
   });
   // Make an ERP from marginal:
-  var dist = new ERP({
+  return new ERP({
     sample: function(params) {
       var x = util.random();
       var probAccum = 0;
@@ -632,18 +632,16 @@ function makeMarginalERP(marginal) {
       return marginal[i].val;
     },
     score: function(params, val) {
-      var lk = marginal[util.serialize(val)];
-      return lk ? Math.log(lk.prob) : -Infinity;
+      var obj = marginal[util.serialize(val)];
+      return obj ? Math.log(obj.prob) : -Infinity;
     },
     support: function(params) {
-      return supp;
+      return support;
     },
     parameterized: false,
-    name: 'marginal'
+    name: 'marginal',
+    hist: marginal
   });
-
-  dist.hist = marginal;
-  return dist;
 }
 
 // note: ps is expected to be normalized

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -612,7 +612,8 @@ function multinomialSample(theta) {
 
 // Make a discrete ERP from a normalized {val: ..., prob: ...} object.
 function makeMarginalERP(marginal) {
-  assert.ok(_.size(marginal) > 0);
+  var norm = _.reduce(marginal, function(acc, obj) { return acc + obj.prob; }, 0);
+  assert.ok(Math.abs(1 - norm) < 1e-8, 'Expected marginal to be normalized.');
   var support = _.map(marginal, function(obj) {
     return obj.val;
   });

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -621,13 +621,10 @@ function makeMarginalERP(marginal) {
     norm = util.logsumexp([norm, d.prob]);
     supp.push(d.val);
   }}
-  var mapEst = {val: undefined, prob: 0};
   for (v in marginal) {if (marginal.hasOwnProperty(v)) {
     var dd = marginal[v];
     var nprob = dd.prob - norm;
     var nprobS = Math.exp(nprob)
-    if (nprobS > mapEst.prob)
-      mapEst = {val: dd.val, prob: nprobS};
     marginal[v].prob = nprobS;
   }}
 
@@ -657,7 +654,6 @@ function makeMarginalERP(marginal) {
     name: 'marginal'
   });
 
-  dist.MAP = function() {return mapEst};
   dist.hist = marginal;
   return dist;
 }

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -6,9 +6,9 @@
 var _ = require('underscore');
 var assert = require('assert');
 var util = require('../util');
-var erp = require('../erp');
 var Hashtable = require('../hashtable').Hashtable
 var Query = require('../query').Query;
+var aggregation = require('../aggregation');
 
 module.exports = function(env) {
 
@@ -768,12 +768,10 @@ module.exports = function(env) {
     this.s = s;
     this.a = a;
 
-    this.onlyMAP = onlyMAP;
-    if (justSample)
-      this.returnSamps = [];
-    else
-      this.returnHist = {};
-    this.MAP = { val: undefined, score: -Infinity };
+    this.aggregator = (justSample || onlyMAP) ?
+        new aggregation.MAP(justSample) :
+        new aggregation.Histogram();
+
     this.totalIterations = numIterations;
     this.acceptedProps = 0;
     this.lag = lag;
@@ -902,22 +900,7 @@ module.exports = function(env) {
           if (val === env.query)
             val = this.query.getTable();
           // add val to hist:
-          if (!this.onlyMAP) {
-            if (this.returnSamps)
-              this.returnSamps.push({score: this.score, value: val})
-            else {
-              var stringifiedVal = util.serialize(val);
-              if (this.returnHist[stringifiedVal] === undefined) {
-                this.returnHist[stringifiedVal] = { prob: 0, val: val };
-              }
-              this.returnHist[stringifiedVal].prob += 1;
-            }
-          }
-          // also update the MAP
-          if (this.score > this.MAP.score) {
-            this.MAP.score = this.score;
-            this.MAP.value = val;
-          }
+          this.aggregator.add(val, this.score);
         }
 
         if (DEBUG >= 6) {
@@ -948,21 +931,6 @@ module.exports = function(env) {
         }
       }
     } else {
-      var hist;
-      if (this.returnSamps || this.onlyMAP) {
-        hist = {};
-        hist[util.serialize(this.MAP.value)] = { prob: 1, val: this.MAP.value };
-      } else {
-        hist = this.returnHist;
-      }
-      var dist = erp.makeMarginalERP(util.logHist(hist));
-      if (this.returnSamps) {
-        if (this.onlyMAP)
-          this.returnSamps.push(this.MAP);
-        dist.samples = this.returnSamps;
-      }
-      dist.MAP = this.MAP.value;
-
       // Reinstate previous coroutine:
       var k = this.k;
       env.coroutine = this.oldCoroutine;
@@ -973,7 +941,7 @@ module.exports = function(env) {
       }
 
       // Return by calling original continuation:
-      return k(this.oldStore, dist);
+      return k(this.oldStore, this.aggregator.toERP());
     }
   };
 

--- a/src/util.js
+++ b/src/util.js
@@ -66,12 +66,6 @@ function product(xs) {
   return result;
 }
 
-var logHist = function(hist) {
-  return _.mapObject(hist, function(x) {
-    return {prob: Math.log(x.prob), val: x.val}
-  });
-};
-
 function logsumexp(a) {
   var m = Math.max.apply(null, a);
   var sum = 0;
@@ -227,7 +221,6 @@ module.exports = {
   histsApproximatelyEqual: histsApproximatelyEqual,
   gensym: gensym,
   logsumexp: logsumexp,
-  logHist: logHist,
   deleteIndex: deleteIndex,
   makeGensym: makeGensym,
   prettyJSON: prettyJSON,


### PR DESCRIPTION
The main change here is a switch to using `Histogram` (and other 'aggregators') in all inference algorithms, which closes #284.

This slightly changes the MCMC interface when `justSample` or `onlyMAP` are used as described [here](https://github.com/probmods/webppl/issues/284#issuecomment-171010017).

This also includes a few additional changes which seemed reasonable to tackle at the same time. The main benefits of these are:

* `makeMarginalERP` no longer adds a `MAP` method to the returned ERP as there is already [a similar method](https://github.com/probmods/webppl/blob/2a5775e6251c9e233a30e2ddd39c0d44b4d1579b/src/erp.ad.js#L43) on the ERP prototype. The only reason I can think of to keep the `makeMarginalERP` specific [version](https://github.com/probmods/webppl/blob/2a5775e6251c9e233a30e2ddd39c0d44b4d1579b/src/erp.ad.js#L624) around would be if it were noticeably more performant, but I don't think that's likely to be the case.
* Normalization now happens in the aggregators. Previously all marginals were normalized in log space. With this change, we can continue to do this for the results of `Enumerate` (#109), without having to do so for sample counts. (Where it's unnecessary, right?) There's also yields an opportunity to accumulate the normalizing constant as the histogram is built, though I've not done that yet.
* As a result, `makeMarginalERP` is now quite a bit simpler.
