### PR TITLE
Back cache helper with LRU cache.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "esutils": "^2.0.2",
     "git-rev-2": "^0.1.0",
     "immutable": "^3.7.5",
+    "lru-cache": "^4.0.0",
     "minimist": "^1.2.0",
     "numeric": "^1.2.6",
     "priorityqueuejs": "~1.0.0",

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -15,7 +15,7 @@ module.exports = function(env) {
   // caching is across all uses of f, even in different execuation
   // paths.
   function cache(s, k, a, f, maxSize) {
-    var c = LRU(maxSize !== undefined ? maxSize : 1e4);
+    var c = LRU(maxSize);
     var cf = function(s, k, a) {
       var args = Array.prototype.slice.call(arguments, 3);
       var stringedArgs = serialize(args);

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var serialize = require('./util').serialize
+var LRU = require('lru-cache');
 
 module.exports = function(env) {
 
@@ -13,25 +14,25 @@ module.exports = function(env) {
   // Caution: if f isn't deterministic weird stuff can happen, since
   // caching is across all uses of f, even in different execuation
   // paths.
-  function cache(s, k, a, f) {
-    var c = {};
+  function cache(s, k, a, f, maxSize) {
+    var c = LRU(maxSize !== undefined ? maxSize : 1e4);
     var cf = function(s, k, a) {
       var args = Array.prototype.slice.call(arguments, 3);
       var stringedArgs = serialize(args);
-      if (stringedArgs in c) {
-        return k(s, c[stringedArgs]);
+      if (c.has(stringedArgs)) {
+        return k(s, c.get(stringedArgs));
       } else {
         var newk = function(s, r) {
-          if (stringedArgs in c) {
+          if (c.has(stringedArgs)) {
             // This can happen when cache is used on recursive functions
             console.log('Already in cache:', stringedArgs);
-            if (serialize(c[stringedArgs]) !== serialize(r)) {
+            if (serialize(c.get(stringedArgs)) !== serialize(r)) {
               console.log('OLD AND NEW CACHE VALUE DIFFER!');
-              console.log('Old value:', c[stringedArgs]);
+              console.log('Old value:', c.get(stringedArgs));
               console.log('New value:', r);
             }
           }
-          c[stringedArgs] = r;
+          c.set(stringedArgs, r);
           return k(s, r);
         };
         return f.apply(this, [s, newk, a].concat(args));

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -33,7 +33,7 @@ module.exports = function(env) {
             }
           }
           c.set(stringedArgs, r);
-          if (!maxSize && c.length === 1e5) {
+          if (!maxSize && c.length === 1e4) {
             console.log(c.length + ' function calls have been cached.');
             console.log('The size of the cache can be limited by calling cache(f, maxSize).');
           }

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -33,6 +33,10 @@ module.exports = function(env) {
             }
           }
           c.set(stringedArgs, r);
+          if (!maxSize && c.length === 1e5) {
+            console.log(c.length + ' function calls have been cached.');
+            console.log('The size of the cache can be limited by calling cache(f, maxSize).');
+          }
           return k(s, r);
         };
         return f.apply(this, [s, newk, a].concat(args));


### PR DESCRIPTION
This uses a LRU cache to back `cache`. It uses the `lru-cache` package which is implemented with a hashmap & doubly-linked list, so I think the asymptotics of `cache` will be unchanged.

This was the main change which helped @mhtess with [this issue](https://groups.google.com/d/msg/webppl-dev/QCO3sDSekzI/Y4Dag1KNBQAJ). The underlying problem there was that Node was running out of memory. This change helps because the model has an instance of the RSA model using `cache` nested within MCMC, where one of the args to one of the cached functions was real-valued (or similar), causing the store used by `cache` to continue growing throughout inference. After this change, memory usage was constant (or close to), and inference wasn't any slower.

There may have been other ways to fix this particular problem, but limiting the amount of memory used by `cache` seems like a reasonable thing to in general.

I've set the default `maxSize` of the store to 10K. MHT was using 1K in the results I mention above, but I bumped that up a little as it felt too conservative.