### PR TITLE
Factor out runTrampoline; use "pausy" version in browser

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -44,26 +44,13 @@ function webpplNaming(code) {
   return escodegen.generate(newProgramAst);
 }
 
-var runTrampoline = function(t) {
-  var lastPauseTime = Date.now();
-  while (t) {
-    var currTime = Date.now();
-    if (currTime - lastPauseTime > 100) {
-      return setTimeout(function() { runTrampoline(t) }, 0);
-    } else {
-      t = t();
-    }
-  }
-}
-
-global.runTrampoline = runTrampoline;
-
 global.webppl = {
   run: run,
   compile: compile,
   cps: webpplCPS,
   naming: webpplNaming,
-  analyze: analyze
+  analyze: analyze,
+  runTrampoline: require('./transforms/trampoline').runner
 };
 
 console.log('webppl loaded.');

--- a/src/browser.js
+++ b/src/browser.js
@@ -44,6 +44,20 @@ function webpplNaming(code) {
   return escodegen.generate(newProgramAst);
 }
 
+var runTrampoline = function(t) {
+  var lastPauseTime = Date.now();
+  while (t) {
+    var currTime = Date.now();
+    if (currTime - lastPauseTime > 100) {
+      return setTimeout(function() { runTrampoline(t) }, 0);
+    } else {
+      t = t();
+    }
+  }
+}
+
+global.runTrampoline = runTrampoline;
+
 global.webppl = {
   run: run,
   compile: compile,

--- a/src/main.js
+++ b/src/main.js
@@ -192,8 +192,6 @@ function runTrampoline(t) {
   }
 }
 
-global.runTrampoline = runTrampoline;
-
 module.exports = {
   requireHeader: requireHeader,
   requireHeaderWrapper: requireHeaderWrapper,

--- a/src/main.js
+++ b/src/main.js
@@ -186,11 +186,20 @@ global.webpplEval = function(s, k, a, code) {
   return eval.call(global, compiledCode)(s, k, a);
 };
 
+function runTrampoline(t) {
+  while (t) {
+    t = t();
+  }
+}
+
+global.runTrampoline = runTrampoline;
+
 module.exports = {
   requireHeader: requireHeader,
   requireHeaderWrapper: requireHeaderWrapper,
   parsePackageCode: parsePackageCode,
   run: run,
   compile: compile,
-  analyze: analyze
+  analyze: analyze,
+  runTrampoline: runTrampoline
 };

--- a/src/transforms/trampoline.js
+++ b/src/transforms/trampoline.js
@@ -47,16 +47,14 @@ function trampoline(node) {
   }
 }
 
-var driver = parse(
-    ['(function(p) {',
-     '  return function(s, k, a) {',
-     '    var trampoline = p(s, k, a);',
-     '    while (trampoline) {',
-     '      trampoline = trampoline();',
-     '    }',
-     '  }',
-     '})'].join('\n')
-    ).body[0].expression;
+
+var driver = parse(['(function (p) {',
+                    '  return function(s, k, a) {',
+                    '    var t = p(s, k, a);',
+                    '    runTrampoline(t);',
+                    '  }',
+                    '})'].join('\n')
+).body[0].expression;
 
 function trampolineMain(node) {
   return inProgram(function(node) {

--- a/src/transforms/trampoline.js
+++ b/src/transforms/trampoline.js
@@ -54,12 +54,12 @@ var cliTrampoline = function(t) {
   }
 };
 
-var webTrampoline = function(t) {
+var webTrampoline = function f(t) {
   var lastPauseTime = Date.now();
   while (t) {
     var currTime = Date.now();
     if (currTime - lastPauseTime > 100) {
-      return setTimeout(function() { webTrampoline(t) }, 0);
+      return setTimeout(function() { f(t) }, 0);
     } else {
       t = t();
     }

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -90,7 +90,7 @@ var transformAstVarargs = compose(varargs, transformAstOptimize);
 var runVarargs = runOptimize;
 
 var transformAstTrampoline = compose(trampoline, transformAstVarargs);
-var _runTrampoline = runVarargs;
+var runTrampoline = runVarargs;
 
 var selectNamingPrimitives = function() {
   // Set global definitions
@@ -180,9 +180,7 @@ function runVarargsTest(test, code, expected) {
 
 function runTrampolineTest(test, code, expected) {
   selectTrampolinePrimitives();
-  // NB: had to prefix runTrampoline with _, otherwise we've hidden the runTrampoline
-  // method
-  return runTest(test, code, expected, transformAstTrampoline, _runTrampoline);
+  return runTest(test, code, expected, transformAstTrampoline, runTrampoline);
 }
 
 function generateTestFunctions(allTests, testRunner) {

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -90,7 +90,7 @@ var transformAstVarargs = compose(varargs, transformAstOptimize);
 var runVarargs = runOptimize;
 
 var transformAstTrampoline = compose(trampoline, transformAstVarargs);
-var runTrampoline = runVarargs;
+var _runTrampoline = runVarargs;
 
 var selectNamingPrimitives = function() {
   // Set global definitions
@@ -180,7 +180,9 @@ function runVarargsTest(test, code, expected) {
 
 function runTrampolineTest(test, code, expected) {
   selectTrampolinePrimitives();
-  return runTest(test, code, expected, transformAstTrampoline, runTrampoline);
+  // NB: had to prefix runTrampoline with _, otherwise we've hidden the runTrampoline
+  // method
+  return runTest(test, code, expected, transformAstTrampoline, _runTrampoline);
 }
 
 function generateTestFunctions(allTests, testRunner) {

--- a/webppl
+++ b/webppl
@@ -48,6 +48,7 @@ function compile(code, packages, verbose, outputFile) {
   var compileOptions = { extra: webppl.parsePackageCode(packages, verbose), verbose: verbose };
 
   compiledCode += (
+    webppl.runTrampoline.toString() + '\n' +
       printWebPPLValue.toString() + '\n' +
       'var topK = function(s, x){ \n' +
       " console.log('\\n* Program return value:\\n'); \n" +


### PR DESCRIPTION
In the browser, we can mimic the responsiveness of running webppl in a Web Worker by using a trampoline that takes occasional breaks (here, every 100ms) to allow DOM updates to happen.