### PR TITLE
Watchify grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore');
 var open = require('open');
-var execSync = require('child_process').execSync;
+var child_process = require('child_process');
 
 var jslintSettings = {
   options: {
@@ -66,6 +66,17 @@ module.exports = function(grunt) {
     clean: ['compiled/*.js']
   });
 
+  function browserifyArgs(args) {
+    var pkgArg = '';
+    if (args.length > 0) {
+      var requires = _.chain(_.toArray(args))
+          .map(function(name) { return ['--require', name]; })
+          .flatten().value();
+      pkgArg = ' -t [' + ['./src/bundle.js'].concat(requires).join(' ') + ']';
+    }
+    return pkgArg + ' -g brfs src/browser.js -o compiled/webppl.js';
+  }
+
   grunt.loadNpmTasks('grunt-gjslint');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
@@ -79,18 +90,21 @@ module.exports = function(grunt) {
   grunt.registerTask('travis-phantomjs', ['compile', 'test-phantomjs']);
 
   grunt.registerTask('compile', 'Compile for the browser', function() {
-    var pkgArg = '';
-    if (arguments.length > 0) {
-      var requires = _.chain(_.toArray(arguments))
-          .map(function(name) { return ['--require', '\"' + name + '\"']; })
-          .flatten().value();
-      pkgArg = ' -t [' + ['./src/bundle.js'].concat(requires).join(' ') + ']';
-    }
-    execSync('mkdir -p compiled');
+    child_process.execSync('mkdir -p compiled');
     grunt.log.writeln('Running browserify');
-    execSync('browserify' + pkgArg + ' -g brfs src/browser.js > compiled/webppl.js');
+    child_process.execSync('browserify' + browserifyArgs(arguments));
     grunt.log.writeln('Running uglifyjs');
-    execSync('uglifyjs compiled/webppl.js -b ascii_only=true,beautify=false > compiled/webppl.min.js');
+    child_process.execSync('uglifyjs compiled/webppl.js -b ascii_only=true,beautify=false > compiled/webppl.min.js');
+  });
+
+  grunt.registerTask('watchify', function() {
+    var done = this.async();
+    child_process.execSync('mkdir -p compiled');
+    var args = '-v' + browserifyArgs(arguments);
+    var p = child_process.spawn('watchify', args.split(' '));
+    p.stdout.on('data', grunt.log.writeln);
+    p.stderr.on('data', grunt.log.writeln);
+    p.on('close', done);
   });
 
   grunt.registerTask('test-browser', function() {
@@ -99,7 +113,8 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test-phantomjs', function() {
     try {
-      var output = execSync('phantomjs node_modules/qunit-phantomjs-runner/runner-list.js tests/browser/index.html');
+      var cmd = 'phantomjs node_modules/qunit-phantomjs-runner/runner-list.js tests/browser/index.html';
+      var output = child_process.execSync(cmd);
       grunt.log.writeln(output);
     } catch (e) {
       grunt.log.writeln(e.output.join('\n'));

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,10 +90,17 @@ module.exports = function(grunt) {
   grunt.registerTask('travis-phantomjs', ['compile', 'test-phantomjs']);
 
   grunt.registerTask('compile', 'Compile for the browser', function() {
+    var taskArgs = (arguments.length > 0) ? ':' + _.toArray(arguments).join(':') : '';
+    grunt.task.run('browserify' + taskArgs, 'uglify');
+  });
+
+  grunt.registerTask('browserify', function() {
     child_process.execSync('mkdir -p compiled');
-    grunt.log.writeln('Running browserify');
     child_process.execSync('browserify' + browserifyArgs(arguments));
-    grunt.log.writeln('Running uglifyjs');
+  });
+
+  grunt.registerTask('uglify', function() {
+    child_process.execSync('mkdir -p compiled');
     child_process.execSync('uglifyjs compiled/webppl.js -b ascii_only=true,beautify=false > compiled/webppl.min.js');
   });
 

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -74,7 +74,14 @@ To compile webppl for use in browser, run::
     npm install -g browserify uglifyjs
     grunt compile
 
-Then, to run the browser tests use::
+The compiled code is written to ``compiled/webppl.js`` and a minified
+version is written to ``compiled/webppl.min.js``.
+
+Testing
+^^^^^^^
+
+To check that compilation was successful, run the browser tests
+using::
 
     grunt test-browser
 
@@ -82,6 +89,9 @@ The tests will run in the default browser. Specify a different browser
 using the ``BROWSER`` environment variable. For example::
 
     BROWSER="Google Chrome" grunt test-browser
+
+Packages
+^^^^^^^^
 
 Packages can also be used in the browser. For example, to include the
 ``webppl-viz`` package use::

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -90,6 +90,23 @@ using the ``BROWSER`` environment variable. For example::
 
     BROWSER="Google Chrome" grunt test-browser
 
+Incremental Compilation
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Repeatedly making changes to the code and then testing the changes in
+the browser can be a slow process. `watchify`_ speeds up this process
+by performing an incremental compile whenever it detects changes to
+source files. To start `watchify`_ use::
+
+    npm install -g watchify
+    grunt watchify
+
+Note that `watchify`_ only updates ``compiled/webppl.js``. Before
+running the browser tests and deploying, create the minified version
+like so::
+
+    grunt uglify
+
 Packages
 ^^^^^^^^
 
@@ -102,3 +119,4 @@ Multiple packages can specified, separated by colons.
 
 .. _continuous integration tests: https://travis-ci.org/probmods/webppl
 .. _nodeunit documentation: https://github.com/caolan/nodeunit#command-line-options
+.. _watchify: https://github.com/substack/watchify


### PR DESCRIPTION
This adds a `grunt watchify` task as requested by @longouyang. When changes are detected this only recompiles `webppl.js`, it doesn't run uglifyjs. (Which would be much slower than the incremental compilation step.) Packages can be included in much the same way as with `grunt compile`. e.g. `grunt watchify:webppl-timeit`.

I've also split the `compile` task into `browserify` and `uglify` tasks. I thought that been able to run `uglify` after `watchify` might be useful.