### PR TITLE
Relax HMC test tolerances.

### DIFF
--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -338,12 +338,14 @@ var tests = [
         }
       },
       mixed3: {
+        hist: { tol: 0.15 },
         args: {
           samples: 2000,
           kernel: { HMC: { steps: 20, stepSize: 1 } }
         }
       },
       mixed3Factor: {
+        hist: { tol: 0.15 },
         args: {
           samples: 2000,
           kernel: { HMC: { steps: 20, stepSize: 1 } }


### PR DESCRIPTION
After this change I ran `mixed3` 2k times with no failures. I've also changed `mixed3Factor` as I saw it fail locally too.

Closes #295.
