### PR TITLE
Don't include values with probability 0 in aggregation

### DIFF
--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -36,6 +36,9 @@ var Distribution = function() {
 };
 
 Distribution.prototype.add = function(value, score) {
+  if (score === -Infinity) {
+    return;
+  }  
   var k = util.serialize(value);
   if (this.dist[k] === undefined) {
     this.dist[k] = { score: -Infinity, val: value };

--- a/src/aggregation.js
+++ b/src/aggregation.js
@@ -38,7 +38,7 @@ var Distribution = function() {
 Distribution.prototype.add = function(value, score) {
   if (score === -Infinity) {
     return;
-  }  
+  }
   var k = util.serialize(value);
   if (this.dist[k] === undefined) {
     this.dist[k] = { score: -Infinity, val: value };


### PR DESCRIPTION
This is the behavior of enumeration before #287, and some models with nested queries rely on this behavior.