### PR TITLE
update ad.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "ad.js": "^1.4.1",
+    "ad.js": "iffsid/ad.js#simple",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "escodegen": "^1.7.0",


### PR DESCRIPTION
This change reflects commit 4facddf in ad.js that undoes the shadowing
of hard functions by their smoothed versions
   - max and min were replaced originally by their approrimate,
     differentiable-everywhere versions
   - this has now been undone and the smoothed versions moved to `smax`
     and `smin`.

Fixes: #303