### PR TITLE
Better verbose mode output for MCMC

### DIFF
--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -23,6 +23,7 @@ module.exports = function(env) {
     var callbacks = options.verbose ?
         [makeVMCallbackForPlatform()].concat(options.callbacks) :
         options.callbacks;
+    _.invoke(callbacks, 'setup', numIters(options));
 
     var aggregator = (options.justSample || options.onlyMAP) ?
         new aggregation.MAP(options.justSample) :
@@ -61,6 +62,10 @@ module.exports = function(env) {
     return kernels.tap(function(trace) {
       fn(trace.value, trace.score);
     });
+  }
+
+  function numIters(opts) {
+    return opts.burn + (opts.lag + 1) * opts.samples;
   }
 
   // Callbacks.

--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -68,7 +68,6 @@ module.exports = function(env) {
   function makeVMCallback(opts) {
     var curIter = 0;
     return {
-      init: _.identity,
       iteration: function(trace) {
         opts.iteration(curIter++);
       },

--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -14,12 +14,15 @@ module.exports = function(env) {
       samples: 100,
       kernel: 'MH',
       lag: 0,
-      burn: 0
+      burn: 0,
+      callbacks: []
     });
 
     options.kernel = kernels.parseOptions(options.kernel);
 
-    var callbacks = options.verbose ? [makeVMCallbackForPlatform()] : [];
+    var callbacks = options.verbose ?
+        [makeVMCallbackForPlatform()].concat(options.callbacks) :
+        options.callbacks;
 
     var aggregator = (options.justSample || options.onlyMAP) ?
         new aggregation.MAP(options.justSample) :

--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -69,7 +69,7 @@ module.exports = function(env) {
     var curIter = 0;
     return {
       iteration: function(trace) {
-        opts.iteration(curIter++);
+        opts.iteration(trace, curIter++);
       },
       finish: function(trace) {
         opts.finish(trace, curIter - 1);
@@ -79,35 +79,30 @@ module.exports = function(env) {
 
   function makeSimpleVMCallback() {
     return makeVMCallback({
-      iteration: function(i) {
-        console.log(formatCurIteration(i));
+      iteration: function(trace, i) {
+        console.log(formatOutput(trace, i));
       },
-      finish: function(trace) {
-        console.log(formatAcceptanceRatio(trace));
-      }
+      finish: _.identity
     });
   }
 
   // Node.js only.
   function makeOverwritingVMCallback() {
-    var writeCurIter = function(i) {
-      process.stdout.write('\r' + formatCurIteration(i));
+    var writeCurIter = function(trace, i) {
+      process.stdout.write('\r' + formatOutput(trace, i));
     };
     return makeVMCallback({
       iteration: _.throttle(writeCurIter, 200, { trailing: false }),
       finish: function(trace, i) {
-        writeCurIter(i);
-        console.log('\n' + formatAcceptanceRatio(trace));
+        writeCurIter(trace, i);
+        console.log();
       }
     });
   }
 
-  function formatCurIteration(i) {
-    return 'Iteration: ' + i;
-  }
-
-  function formatAcceptanceRatio(trace) {
-    return 'Acceptance ratio: ' + (trace.info.accepted / trace.info.total);
+  function formatOutput(trace, i) {
+    var ratio = (trace.info.accepted / trace.info.total).toFixed(4);
+    return 'Iteration: ' + i + ' | Acceptance ratio: ' + ratio;
   }
 
   function makeVMCallbackForPlatform() {


### PR DESCRIPTION
This changes `MCMC`'s verbose mode to overwrite the current line when printing the current iteration to the terminal under Node.js. (#257.)

This doesn't work in the browser, and the behavior there is not changed by this PR. To make it possible to experiment with the idea of showing a progress bar in the browser (#70), this PR also adds a `callbacks` option to `MCMC`. (#197.)

I think it would be reasonable to commit this as is. The following would then be follow-up work:

* Unify this with the `verboseLag` option. (They differ most in the browser.)
* Add callbacks to `IncrementalMH`, and perhaps other algorithms,


