### PR TITLE
AD transform wppl code loaded from packages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -94,8 +94,11 @@ function addHeaderMacrosToEachPair(pairs) {
   // This assumes that pair[0] is the content of the header.
   assert.ok(pairs.length >= 1 && pairs[0].macros.length === 2);
   var headerMacros = pairs[0].macros;
-  return pairs.map(function(pair) {
-    return { code: pair.code, macros: pair.macros.concat(headerMacros) };
+  return pairs.map(function(pair, i) {
+    return {
+      code: pair.code,
+      macros: pair.macros.concat(i > 0 ? headerMacros : [])
+    };
   });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,7 @@ function packagesToPairs(packages) {
 function addHeaderMacrosToEachPair(pairs) {
   // This assumes that pair[0] is the content of the header.
   assert.ok(pairs.length >= 1 && pairs[0].macros.length === 2);
-  var headerMacros = pairs[0].macros[0];
+  var headerMacros = pairs[0].macros;
   return pairs.map(function(pair) {
     return { code: pair.code, macros: pair.macros.concat(headerMacros) };
   });


### PR DESCRIPTION
AD macros aren't expanded in `.wppl` code coming from packages. That's a bug, this fixes it.

Thanks @mhtess.