### PR TITLE
Untapify values passed to display for readability.

### DIFF
--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -2,11 +2,12 @@
 
 var serialize = require('./util').serialize
 var LRU = require('lru-cache');
+var ad = require('./ad');
 
 module.exports = function(env) {
 
   function display(s, k, a, x) {
-    return k(s, console.log(x));
+    return k(s, console.log(ad.untapify(x)));
   }
 
   // Caching for a wppl function f.


### PR DESCRIPTION
If someone does something like this:

````js
var x = uniform(0, 1);
display(x)
````

... and does HMC over it, they're probably surprised to see a big blob of JSON representing the tape as output. This fixes that by calling `ad.untapify` in `display`.

It's not obvious to me that this is the right thing to do. For example, by hiding tapes we make it less likely a user will figure out for themselves why they're having problems passing continuous variables to JS libraries. However, that can be addressed elsewhere, and this is probably worth doing.

`console.log` will still show the tape as before, which I think is useful.