### PR TITLE
Make file names available at parse time

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,13 +50,13 @@ function concatPrograms(programs) {
   return programs.reduce(concat, emptyProgram);
 }
 
-function parse(code, macros) {
+function parse(code, macros, filename) {
   return sweet.compile(code, { readableNames: true, ast: true, modules: macros });
 }
 
 function parseAll(bundles) {
   return bundles.map(function(bundle) {
-    return parse(bundle.code, bundle.macros);
+    return parse(bundle.code, bundle.macros, bundle.filename);
   });
 }
 
@@ -72,19 +72,19 @@ function headerPackage() {
   var code = fs.readFileSync(__dirname + '/header.wppl', 'utf8');
   var headerMacroModule = fs.readFileSync(__dirname + '/headerMacros.sjs', 'utf8');
   var adMacroModule = fs.readFileSync(__dirname + '/../node_modules/ad.js/macros/index.js', 'utf8');
-  return { wppl: [code], macros: [headerMacroModule, adMacroModule] };
+  return { wppl: [{ code: code, filename: 'header.wppl' }], macros: [headerMacroModule, adMacroModule] };
 }
 
 function unpack(packages) {
   // Flatten an array of packages into an array of code bundles. A
-  // bundle contains wppl source code and associated macros.
+  // bundle contains wppl source code, filename and associated macros.
   //
   // Package :: { wppl: [String], macros: [LoadedMacroModule] }
-  // Bundle :: { code: String, macros: [LoadedMacroModule] }
+  // Bundle :: { code: String, filename: String, macros: [LoadedMacroModule] }
   //
   return _.chain(packages).map(function(pkg) {
     return pkg.wppl.map(function(wppl) {
-      return { code: wppl, macros: pkg.macros };
+      return { code: wppl.code, filename: wppl.filename, macros: pkg.macros };
     });
   }).flatten().value();
 }
@@ -96,6 +96,7 @@ function addHeaderMacrosToEachBundle(bundles) {
   return bundles.map(function(bundle, i) {
     return {
       code: bundle.code,
+      filename: bundle.filename,
       macros: bundle.macros.concat(i > 0 ? headerMacros : [])
     };
   });
@@ -140,7 +141,12 @@ function copyAst(ast) {
 }
 
 function compile(code, options) {
-  options = util.mergeDefaults(options, { verbose: false, generateCode: true });
+  options = util.mergeDefaults(options, {
+    verbose: false,
+    generateCode: true,
+    filename: 'webppl:program'
+  });
+
   var extra = options.extra || parsePackageCode([], options.verbose);
 
   var transforms = options.transforms || [
@@ -154,7 +160,7 @@ function compile(code, options) {
   ];
 
   function _compile() {
-    var programAst = parse(code, extra.macros);
+    var programAst = parse(code, extra.macros, options.filename);
     var asts = extra.asts.map(copyAst).concat(programAst);
     var doCaching = _.any(asts, caching.transformRequired);
 

--- a/src/main.js
+++ b/src/main.js
@@ -54,9 +54,9 @@ function parse(code, macros) {
   return sweet.compile(code, { readableNames: true, ast: true, modules: macros });
 }
 
-function parseAllPairs(pairs) {
-  return pairs.map(function(pair) {
-    return parse(pair.code, pair.macros);
+function parseAll(bundles) {
+  return bundles.map(function(bundle) {
+    return parse(bundle.code, bundle.macros);
   });
 }
 
@@ -75,14 +75,13 @@ function headerPackage() {
   return { wppl: [code], macros: [headerMacroModule, adMacroModule] };
 }
 
-function packagesToPairs(packages) {
-  // Transform an array of packages into an array of pairs. A pair
-  // contains a string of WebPPL code and an array of macros required
-  // to parse that code.
-
+function unpack(packages) {
+  // Flatten an array of packages into an array of code bundles. A
+  // bundle contains wppl source code and associated macros.
+  //
   // Package :: { wppl: [String], macros: [LoadedMacroModule] }
-  // Pair :: { code: String, macros: [LoadedMacroModule] }
-
+  // Bundle :: { code: String, macros: [LoadedMacroModule] }
+  //
   return _.chain(packages).map(function(pkg) {
     return pkg.wppl.map(function(wppl) {
       return { code: wppl, macros: pkg.macros };
@@ -90,14 +89,14 @@ function packagesToPairs(packages) {
   }).flatten().value();
 }
 
-function addHeaderMacrosToEachPair(pairs) {
+function addHeaderMacrosToEachBundle(bundles) {
   // This assumes that pair[0] is the content of the header.
-  assert.ok(pairs.length >= 1 && pairs[0].macros.length === 2);
-  var headerMacros = pairs[0].macros;
-  return pairs.map(function(pair, i) {
+  assert.ok(bundles.length >= 1 && bundles[0].macros.length === 2);
+  var headerMacros = bundles[0].macros;
+  return bundles.map(function(bundle, i) {
     return {
-      code: pair.code,
-      macros: pair.macros.concat(i > 0 ? headerMacros : [])
+      code: bundle.code,
+      macros: bundle.macros.concat(i > 0 ? headerMacros : [])
     };
   });
 }
@@ -115,9 +114,9 @@ function parsePackageCode(packages, verbose) {
     var macros = _.chain(allPackages).pluck('macros').flatten().value();
 
     var asts = util.pipeline([
-      packagesToPairs,
-      addHeaderMacrosToEachPair,
-      parseAllPairs
+      unpack,
+      addHeaderMacrosToEachBundle,
+      parseAll
     ])(allPackages);
 
     return { asts: asts, macros: macros };

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -2,16 +2,18 @@
 
 var webppl = require('../src/main');
 
+var wpplPkgEntry = function(code) { return { code: code, filename: '' }; };
+
 var pkg1 = {
   wppl: ['var inc = function(x) { x + 1 };' +
          'var fnWithMacro = function() { return m1; };' +
-         'var fnWithHeaderMacro = function() { 1 |> inc };'],
+         'var fnWithHeaderMacro = function() { 1 |> inc };'].map(wpplPkgEntry),
   macros: ["macro m1 { rule {} => { 'macro' } }; export m1;"]
 };
 
 var pkg2 = {
   wppl: ['var fnWithPkg1Macro = function() { m1 };' +
-         'var fnWithPkg2Macro = function() { m2 };'],
+         'var fnWithPkg2Macro = function() { m2 };'].map(wpplPkgEntry),
   macros: ["macro m2 { rule {} => { 'macro2' } }; export m2;"]
 };
 

--- a/webppl
+++ b/webppl
@@ -25,7 +25,7 @@ function topK(s,x) {
 
 var cliRunner = util.trampolineRunners.cli;
 
-function run(code, packages, verbose) {
+function run(code, packages, verbose, programFile) {
   packages.forEach(function(pkg) {
     if (pkg.js) { global[pkg.js.identifier] = require(pkg.js.path); }
     pkg.headers.forEach(webppl.requireHeader);
@@ -39,6 +39,7 @@ function run(code, packages, verbose) {
       },
       {
         extra: webppl.parsePackageCode(packages, verbose),
+        filename: programFile,
         verbose: verbose
       });
 }
@@ -47,7 +48,7 @@ var lines = function(ar) {
   return ar.join('\n')
 }
 
-function compile(code, packages, verbose, outputFile) {
+function compile(code, packages, verbose, programFile, outputFile) {
   var compiledCode = 'var webppl = require("' + require.resolve('./src/main') + '");\n';
   packages.forEach(function(pkg) {
     if (pkg.js) { compiledCode += 'var ' + pkg.js.identifier + ' = require("' + pkg.js.path + '");\n'; }
@@ -56,7 +57,11 @@ function compile(code, packages, verbose, outputFile) {
     });
   });
 
-  var compileOptions = { extra: webppl.parsePackageCode(packages, verbose), verbose: verbose };
+  var compileOptions = {
+    extra: webppl.parsePackageCode(packages, verbose),
+    filename: programFile,
+    verbose: verbose
+  };
 
   var compiledBody = webppl.compile(code, compileOptions);
 
@@ -131,7 +136,7 @@ function main() {
     util.seedRNG(seed);
   }
 
-  processCode(code, packages, argv.verbose, outputFile);
+  processCode(code, packages, argv.verbose, programFile, outputFile);
 }
 
 main();


### PR DESCRIPTION
This makes the source file name of wppl code available at parse time. Nothing makes use of this information yet, but the idea is that #292 & #314 can build on this change.

Subtleties:

* In the browser, package file names are truncated. e.g. `/Users/edward/webppl-viz/src/viz.wppl` becomes `webppl-viz/src/viz.wppl`. We don't want information about the person building the browser version included in the build.
* Where file names are not available (i.e. programs run in the browser, `webpplEval`) the string `webppl:program` is used instead.