### PR TITLE
Remove superfluous methods.

### DIFF
--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <title>WebPPL</title>
     <script src="../../compiled/webppl.min.js"></script>
-    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.19.0.css">
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.21.0.css">
   </head>
   <body>
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
-    <script src="http://code.jquery.com/qunit/qunit-1.19.0.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-1.21.0.js"></script>
     <script src="tests.js"></script>
   </body>
 </html>

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -1,15 +1,19 @@
 'use strict';
 
 QUnit.test('run', function(test) {
+  var done = test.async();
   webppl.run('Enumerate(flip)', function(s, erp) {
     test.ok(_.isEqual([false, true], erp.support().sort()));
+    done();
   });
 });
 
 QUnit.test('run twice', function(test) {
+  var done = test.async(2);
   _.times(2, function() {
     webppl.run('Enumerate(flip)', function(s, erp) {
       test.ok(_.isEqual([false, true], erp.support().sort()));
+      done();
     });
   });
 });

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -1,13 +1,5 @@
 'use strict';
 
-var compile = function(code) {
-  return webppl.compile(code, {trampolineRunner: 'cli'});
-};
-
-var run = function(code) {
-  return webppl.run(code, {trampolineRunner: 'cli'});
-}
-
 QUnit.test('run', function(test) {
   webppl.run('Enumerate(flip)', function(s, erp) {
     test.ok(_.isEqual([false, true], erp.support().sort()));
@@ -23,7 +15,7 @@ QUnit.test('run twice', function(test) {
 });
 
 QUnit.test('compile', function(test) {
-  test.ok(_.isString(compile('1 + 1')));
+  test.ok(_.isString(webppl.compile('1 + 1')));
 });
 
 QUnit.test('cps', function(test) {


### PR DESCRIPTION
These came along with the new trampoline runner, but I'm not sure they do anything useful.

`compile` doesn't appear to take a `trampolineRunner`option, and `run`'s second arg is a continuation not and options object.
