### PR TITLE
Show webppl version in the browser

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,12 +68,10 @@ module.exports = function(grunt) {
 
   function browserifyArgs(args) {
     var pkgArg = '';
-    if (args.length > 0) {
-      var requires = _.chain(_.toArray(args))
-          .map(function(name) { return ['--require', name]; })
-          .flatten().value();
-      pkgArg = ' -t [' + ['./src/bundle.js'].concat(requires).join(' ') + ']';
-    }
+    var requires = _.chain(_.toArray(args))
+        .map(function(name) { return ['--require', name]; })
+        .flatten().value();
+    pkgArg = ' -t [' + ['./src/bundle.js'].concat(requires).join(' ') + ']';
     return pkgArg + ' -g brfs src/browser.js -o compiled/webppl.js';
   }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "estemplate": "^0.4.0",
     "estraverse": "^4.1.0",
     "esutils": "^2.0.2",
-    "git-rev-2": "^0.1.0",
+    "git-rev-2": "yanatan16/git-rev#bfc97b3d",
     "immutable": "^3.7.5",
     "lru-cache": "^4.0.0",
     "minimist": "^1.2.0",

--- a/src/browser.js
+++ b/src/browser.js
@@ -13,7 +13,8 @@ var thunkify = require('./syntax').thunkify;
 var cps = require('./transforms/cps').cps;
 var analyze = require('./analysis/main').analyze;
 
-// This is populated by the bundle.js browserify transform.
+// These are populated by the bundle.js browserify transform.
+var version = '';
 var packages = [];
 
 var load = _.once(function() {
@@ -24,7 +25,7 @@ var load = _.once(function() {
     pkg.headers.forEach(webppl.requireHeaderWrapper);
   });
   var extra = webppl.parsePackageCode(packages);
-  console.log('webppl loaded.');
+  console.log('webppl ' + version + ' loaded.');
   return extra;
 });
 

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,17 @@
+var git = require('git-rev-2');
+
+function get(dirname, callback) {
+  git.branch(
+      dirname,
+      function(err, branch) {
+        dirname,
+        git.short(
+            function(err, short) {
+              callback({ branch: branch, short: short });
+            });
+      });
+}
+
+module.exports = {
+  get: get
+};

--- a/src/version.js
+++ b/src/version.js
@@ -5,9 +5,9 @@ function get(dirname, callback) {
       dirname,
       function(err, branch) {
         dirname,
-        git.short(
-            function(err, short) {
-              callback({ branch: branch, short: short });
+        git.describe(
+            function(err, describe) {
+              callback({ branch: branch, describe: describe });
             });
       });
 }

--- a/webppl
+++ b/webppl
@@ -88,7 +88,7 @@ function main() {
   // Print version if requested
   if (argv.version) {
     version.get(__dirname, function(ver) {
-      console.log(ver.branch, ver.short, __dirname);
+      console.log(ver.branch, ver.describe, __dirname);
     });
     return;
   }

--- a/webppl
+++ b/webppl
@@ -7,7 +7,7 @@ var webppl = require('./src/main');
 var pkg = require('./src/pkg');
 var util = require('./src/util');
 var parseArgs = require('minimist');
-var git = require('git-rev-2');
+var version = require('./src/version');
 var _ = require('underscore');
 
 function printWebPPLValue(x) {
@@ -87,16 +87,9 @@ function main() {
 
   // Print version if requested
   if (argv.version) {
-    git.branch(
-        __dirname,
-        function(err, branch) {
-          __dirname,
-          git.short(
-              function(err, shortName) {
-                console.log(branch, shortName, __dirname);
-              });
-        }
-    );
+    version.get(__dirname, function(ver) {
+      console.log(ver.branch, ver.short, __dirname);
+    });
     return;
   }
 


### PR DESCRIPTION
This includes the output of [`git describe`](https://git-scm.com/docs/git-describe) in the browser when webppl is loaded. (Addressing the first part of #313.)

I've updated `webppl --version` to also include this information.

