### PR TITLE
Further relax HMC inference test tolerance.

### DIFF
--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -431,7 +431,7 @@ var tests = [
       nestedEnum2: { mean: { tol: 0.075 }, std: { tol: 0.075 } },
       nestedEnum3: { mean: { tol: 0.075 }, std: { tol: 0.075 } },
       nestedEnum4: { hist: { exact: true } },
-      nestedEnum5: { mean: { tol: 0.075 }, std: { tol: 0.075 } },
+      nestedEnum5: { mean: { tol: 0.085 }, std: { tol: 0.075 } },
       nestedEnum6: { mean: { tol: 0.075 }, std: { tol: 0.075 } },
       nestedEnum7: { mean: { tol: 0.075 }, std: { tol: 0.075 } },
       nestedEnum8: {


### PR DESCRIPTION
From #350:

> It looks like the test tolerances are still too low (or there is a bug in the algorithm):
> https://travis-ci.org/probmods/webppl/jobs/111013425

Across multiple tests, the distribution of the mean looks pretty sensible. The tolerances were too low before, but at 0.075 the tolerance (for the mean of nestedEnum5) is roughly 4 SD of the empirical distribution. I ran the test 5K times and only saw one test failure, which seems about right if we assume the distribution is Gaussian. I've bumped it up a little further (~4.5 SD) to give us more room. Sound OK?