### PR TITLE
Make sources available within compile.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -24,16 +24,16 @@ var load = _.once(function() {
     if (pkg.js) { global[pkg.js.identifier] = pkg.js.path; }
     pkg.headers.forEach(webppl.requireHeaderWrapper);
   });
-  var extra = webppl.parsePackageCode(packages);
+  var bundles = webppl.parsePackageCode(packages);
   console.log('webppl ' + version + ' loaded.');
-  return extra;
+  return bundles;
 });
 
 function run(code, k, options) {
   if (options === undefined) {
     options = {};
   }
-  var optionsExtended = _.extend({extra: load()}, options);
+  var optionsExtended = _.extend({bundles: load()}, options);
 
   return webppl.run(code, k, optionsExtended);
 }
@@ -42,7 +42,7 @@ function compile(code, options) {
   if (options === undefined) {
     options = {};
   }
-  var optionsExtended = _.extend({extra: load()}, options);
+  var optionsExtended = _.extend({bundles: load()}, options);
   return webppl.compile(code, optionsExtended);
 }
 

--- a/tests/test-macros.js
+++ b/tests/test-macros.js
@@ -19,8 +19,8 @@ var pkg2 = {
 
 var wpplRunWithPkgs = function(code, packages) {
   var val;
-  var extra = webppl.parsePackageCode(packages);
-  webppl.run(code, function(s, v) { val = v; }, { extra: extra });
+  var bundles = webppl.parsePackageCode(packages);
+  webppl.run(code, function(s, v) { val = v; }, { bundles: bundles });
   return val;
 };
 

--- a/webppl
+++ b/webppl
@@ -38,7 +38,7 @@ function run(code, packages, verbose, programFile) {
         printWebPPLValue(x);
       },
       {
-        extra: webppl.parsePackageCode(packages, verbose),
+        bundles: webppl.parsePackageCode(packages, verbose),
         filename: programFile,
         verbose: verbose
       });
@@ -58,7 +58,7 @@ function compile(code, packages, verbose, programFile, outputFile) {
   });
 
   var compileOptions = {
-    extra: webppl.parsePackageCode(packages, verbose),
+    bundles: webppl.parsePackageCode(packages, verbose),
     filename: programFile,
     verbose: verbose
   };


### PR DESCRIPTION
The key change here is to `parseAll`, where instead of returning just the ast, we augment the 'bundle' we took as input with the ast. The makes all original source code available in `compile` which we appear to need for #292.

The rest is mostly just renaming `extras` to `bundles` everywhere, as the thing returned from `parsePackageCode` is now an array of 'bundles', and not this awkward object which I often called extras. (Which looked like `{ ast: '', macros: [] }`.)

I've tested compiling for the browser with packages, and it still works.
