### PR TITLE
Inference tests for Enum nested in IncrementalMH.

### DIFF
--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -80,7 +80,16 @@ var tests = [
       optionalErpParams: true,
       variableSupport: true,
       query: true,
-      onlyMAP: { mean: { tol: 0.1 }, args: [150, { onlyMAP: true }] }
+      onlyMAP: { mean: { tol: 0.1 }, args: [150, { onlyMAP: true }] },
+      nestedEnum1: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum2: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum3: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum4: { hist: { exact: true } },
+      nestedEnum5: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum6: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum7: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnum8: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
+      nestedEnumWithFactor: { mean: { tol: 0.1 }, std: { tol: 0.075 } }
     }
   },
   {


### PR DESCRIPTION
Note that before the bug described in #316 was fixed, these tests would not have passed (very often).

I've set the tolerances to those used by the `MH` nested enum tests. Hopefully they won't need tweaking...
