### PR TITLE
Add 'grunt watch'.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,13 @@ module.exports = function(grunt) {
     },
     gjslint: jslintSettings,
     fixjsstyle: jslintSettings,
-    clean: ['compiled/*.js']
+    clean: ['compiled/*.js'],
+    watch: {
+      ad: {
+        files: ['**/*.ad.js'],
+        tasks: ['adify']
+      }
+    }
   });
 
   function browserifyArgs(args) {
@@ -79,6 +85,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.registerTask('default', ['gjslint', 'nodeunit']);
   grunt.registerTask('test', ['nodeunit']);
@@ -86,6 +93,11 @@ module.exports = function(grunt) {
   grunt.registerTask('hint', ['jshint']);
   grunt.registerTask('fixstyle', ['fixjsstyle']);
   grunt.registerTask('travis-phantomjs', ['compile', 'test-phantomjs']);
+
+  grunt.registerTask('adify', function() {
+    var output = child_process.execSync('scripts/adify');
+    grunt.log.writeln(output);
+  });
 
   grunt.registerTask('compile', 'Compile for the browser', function() {
     var taskArgs = (arguments.length > 0) ? ':' + _.toArray(arguments).join(':') : '';

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -19,7 +19,13 @@ Files with names which end with ``.ad.js`` are transformed to use AD
 primitives when WebPPL is installed.
 
 During development it is necessary to run this transform after any
-such files have been modified. This is done with::
+such files have been modified. A grunt task is provided that will
+monitor the file system and run the transform when any ``.ad.js``
+files are updated. Start the task with::
+
+    grunt watch
+
+Alternatively, the transform can be run directly with::
 
     ./scripts/adify
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-contrib-clean": "^0.7.0",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-nodeunit": "^0.4.1",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-gjslint": "^0.2.0",
     "nodeunit": "^0.9.1",
     "open": "0.0.5",

--- a/scripts/adify
+++ b/scripts/adify
@@ -10,7 +10,7 @@ function findFiles(root, regex) {
   function walk(dir) {
     fs.readdirSync(dir).forEach(function(f) {
       var p = path.join(dir, f);
-      if (fs.statSync(p).isDirectory()) {
+      if (fs.lstatSync(p).isDirectory()) {
         walk(p);
       } else if (f.match(regex)) {
         matches.push(p);
@@ -23,7 +23,6 @@ function findFiles(root, regex) {
 }
 
 var root = path.join(__dirname, '..', 'src');
-var adregex = /\.ad\.js$/;
 
 function adRequirePath(srcFilename) {
   var dir = path.dirname(srcFilename);
@@ -32,8 +31,9 @@ function adRequirePath(srcFilename) {
   return adPath + path.sep + 'ad.js';
 }
 
-findFiles(root, adregex).forEach(function(inFile) {
-  var outFile = inFile.replace(adregex, '.js');
+// Don't match text editor temporary files. e.g. src/.#erp.ad.js
+findFiles(root, /^(\w.*)\.ad\.js$/).forEach(function(inFile) {
+  var outFile = inFile.replace(/\.ad\.js$/, '.js');
   var code = fs.readFileSync(inFile, 'utf8');
   fs.writeFileSync(outFile, adify(code, adRequirePath(inFile)));
 });


### PR DESCRIPTION
This adds a new grunt task that automatically runs `scipts/adify` when `.ad.fs` files are changed.

It's unfortunate that we now have `grunt watch` and `grunt watchify`, but I think it's best if I try and improve that as a separate PR.