### PR TITLE
Use adnn for AD

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "ad.js": "iffsid/ad.js#simple",
+    "adnn": "^1.0.0",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "escodegen": "^1.7.0",

--- a/src/ad.js
+++ b/src/ad.js
@@ -1,20 +1,20 @@
 'use strict';
 
 var _ = require('underscore');
-var ad = require('ad.js')({ mode: 'r', noHigher: true });
+var ad = require('adnn/ad');
 
-ad.isTape = function(obj) {
-  return _.has(obj, 'primal');
-};
-
-// Recursively untapify objects. ad.js already does this for arrays,
-// here we extend that to other objects.
-ad.deepUntapify = function(x) {
-  if (_.isObject(x) && !_.isArray(x) && !ad.isTape(x)) {
-    return _.mapObject(x, ad.deepUntapify);
+var valueRec = function(x) {
+  if (ad.isLifted(x)) {
+    return x.x;
+  } else if (_.isArray(x)) {
+    return _.map(x, valueRec);
+  } else if (_.isObject(x) && !_.isFunction(x)) {
+    return _.mapObject(x, valueRec);
   } else {
-    return ad.untapify(x);
+    return x;
   }
 };
+
+ad.valueRec = valueRec;
 
 module.exports = ad;

--- a/src/aggregation/histogram.js
+++ b/src/aggregation/histogram.js
@@ -10,7 +10,7 @@ var Histogram = function() {
 };
 
 Histogram.prototype.add = function(value) {
-  var value = ad.deepUntapify(value);
+  var value = ad.valueRec(value);
   var k = util.serialize(value);
   if (this.hist[k] === undefined) {
     this.hist[k] = { count: 0, val: value };

--- a/src/aggregation/map.js
+++ b/src/aggregation/map.js
@@ -12,8 +12,8 @@ var MAP = function(retainSamples) {
 };
 
 MAP.prototype.add = function(value, score) {
-  var value = ad.deepUntapify(value);
-  var score = ad.untapify(score);
+  var value = ad.valueRec(value);
+  var score = ad.value(score);
   if (this.retainSamples) {
     this.samples.push({ value: value, score: score });
   }

--- a/src/header.js
+++ b/src/header.js
@@ -73,7 +73,7 @@ module.exports = function(env) {
   };
 
   env.factor = function(s, k, a, score) {
-    assert.ok(!isNaN(ad.untapify(score)), 'factor() score was NaN');
+    assert.ok(!isNaN(ad.value(score)), 'factor() score was NaN');
     return env.coroutine.factor(s, k, a, score);
   };
 

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -7,7 +7,7 @@ var ad = require('./ad');
 module.exports = function(env) {
 
   function display(s, k, a, x) {
-    return k(s, console.log(ad.untapify(x)));
+    return k(s, console.log(ad.valueRec(x)));
   }
 
   // Caching for a wppl function f.

--- a/src/inference/initialize.js
+++ b/src/inference/initialize.js
@@ -32,8 +32,8 @@ module.exports = function(env) {
   };
 
   Initialize.prototype.sample = function(s, k, a, erp, params) {
-    var _val = erp.sample(ad.untapify(params));
-    var val = this.ad && erp.isContinuous ? ad.tapify(_val) : _val;
+    var _val = erp.sample(ad.valueRec(params));
+    var val = this.ad && erp.isContinuous ? ad.lift(_val) : _val;
     this.trace.addChoice(erp, params, val, a, s, k);
     return k(s, val);
   };
@@ -42,7 +42,7 @@ module.exports = function(env) {
     if (score === -Infinity) {
       return this.fail();
     }
-    this.trace.score = ad.add(this.trace.score, score);
+    this.trace.score = ad.scalar.add(this.trace.score, score);
     return k(s);
   };
 

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -54,9 +54,9 @@ module.exports = function(env) {
 
   SMC.prototype.sample = function(s, k, a, erp, params) {
     var importanceERP = erp.importanceERP || erp;
-    var _params = ad.untapify(params);
+    var _params = ad.valueRec(params);
     var _val = importanceERP.sample(_params);
-    var val = this.adRequired && importanceERP.isContinuous ? ad.tapify(_val) : _val;
+    var val = this.adRequired && importanceERP.isContinuous ? ad.lift(_val) : _val;
     var importanceScore = importanceERP.score(_params, _val);
     var choiceScore = erp.score(_params, _val);
     var particle = this.currentParticle();
@@ -73,8 +73,8 @@ module.exports = function(env) {
     var particle = this.currentParticle();
     particle.trace.numFactors += 1;
     particle.trace.saveContinuation(s, k);
-    particle.trace.score = ad.add(particle.trace.score, score);
-    particle.logWeight += ad.untapify(score);
+    particle.trace.score = ad.scalar.add(particle.trace.score, score);
+    particle.logWeight += ad.value(score);
     this.debugLog('(' + this.particleIndex + ') Factor: ' + a);
     return this.sync();
   };

--- a/src/main.js
+++ b/src/main.js
@@ -72,7 +72,7 @@ function headerPackage() {
   // Create a pseudo package from the header.
   var code = fs.readFileSync(__dirname + '/header.wppl', 'utf8');
   var headerMacroModule = fs.readFileSync(__dirname + '/headerMacros.sjs', 'utf8');
-  var adMacroModule = fs.readFileSync(__dirname + '/../node_modules/ad.js/macros/index.js', 'utf8');
+  var adMacroModule = fs.readFileSync(__dirname + '/../node_modules/adnn/ad/macros.sjs', 'utf8');
   return { wppl: [{ code: code, filename: 'header.wppl' }], macros: [headerMacroModule, adMacroModule] };
 }
 

--- a/src/trace.js
+++ b/src/trace.js
@@ -76,7 +76,7 @@ Trace.prototype.addChoice = function(erp, params, val, address, store, continuat
   this.choices.push(choice);
   this.addressMap[address] = choice;
   this.length += 1;
-  this.score = ad.add(this.score, erp.score(params, val));
+  this.score = ad.scalar.add(this.score, erp.score(params, val));
   // this.checkConsistency();
 };
 

--- a/src/transforms/adify.js
+++ b/src/transforms/adify.js
@@ -10,7 +10,7 @@ var sweet = require('sweet.js');
 var _ = require('underscore');
 var util = require('../util');
 
-var adMacros = sweet.loadNodeModule(null, 'ad.js/macros');
+var adMacros = sweet.loadNodeModule(null, 'adnn/ad/macros.sjs');
 var sweetOptions = { modules: adMacros, readableNames: true, ast: true };
 
 function expandMacros(code) {

--- a/tests/test-analysis.js
+++ b/tests/test-analysis.js
@@ -5,7 +5,7 @@ var analysis = require('../src/analysis/main');
 var Set = require('immutable').Set;
 
 var tests = {
-  // Commented out as AD macros now transform '+' into 'ad.add' which
+  // Commented out as AD macros now transform '+' into 'ad.scalar.add' which
   // causes the test to fail.
   // constant: {
   //   program: '3 + 4',

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -250,6 +250,8 @@ var tests = [
     func: 'SMC',
     settings: {
       hist: { tol: 0.1 },
+      mean: { tol: 0.2 },
+      std: { tol: 0.2 },
       logZ: { check: true, tol: 0.1 },
       MAP: { tol: 0.1, check: true },
       args: { particles: 1000, rejuvSteps: 10, rejuvKernel: 'HMC' }
@@ -263,7 +265,9 @@ var tests = [
         mean: { tol: 0.3 },
         std: { tol: 0.3 }
       },
-      nestedEnumWithFactor: { mean: { tol: 0.075 }, std: { tol: 0.05 } }
+      nestedEnumWithFactor: { mean: { tol: 0.075 }, std: { tol: 0.05 } },
+      gaussianMean: { args: { particles: 1000, rejuvSteps: 2, rejuvKernel: 'HMC' } },
+      gaussianMeanVar: { args: { particles: 1000, rejuvSteps: 2, rejuvKernel: 'HMC' } }
     }
   },
   {


### PR DESCRIPTION
This changes the ad library used for HMC from ad.js to adnn.

This is a first step towards #286, #259.

For the kinds of models I've used while implementing & testing HMC I think adnn is a little slower than ad.js.

For example, I ran a few iterations of the model MHT has been using to experiment with HMC under both versions. The avg. run-time (over 5 runs) for each was:

````
ad.js |  8.8s
adnn  |  9.5s
````

The gap would have been bigger than this, but Daniel and I have spent some time staring at the output of the profiler and found some improvements.

(These timings were taken using the most recent commit on master. We won't pull the last tweak we made into WebPPL until there's another npm release of adnn.)

I think we're at a point where this is close enough to merge.