### PR TITLE
Make Histogram not break prototype chain when it adds values.

### DIFF
--- a/src/ad.js
+++ b/src/ad.js
@@ -9,11 +9,11 @@ var valueRec = function(x) {
   } else if (_.isArray(x)) {
     return _.map(x, valueRec);
   } else if (_.isObject(x) && !_.isFunction(x)) {
-  	// Ensure prototype chain is preserved
-  	var proto = Object.getPrototypeOf(x);
-  	var y = _.mapObject(x, valueRec);
-  	Object.setPrototypeOf(y, proto);
-  	return y;
+    // Ensure prototype chain is preserved
+    var proto = Object.getPrototypeOf(x);
+    var y = _.mapObject(x, valueRec);
+    Object.setPrototypeOf(y, proto);
+    return y;
   } else {
     return x;
   }

--- a/src/ad.js
+++ b/src/ad.js
@@ -12,7 +12,7 @@ var valueRec = function(x) {
     // Ensure prototype chain is preserved
     var proto = Object.getPrototypeOf(x);
     var y = _.mapObject(x, valueRec);
-    Object.setPrototypeOf(y, proto);
+    return _.extendOwn(Object.create(proto), y);
     return y;
   } else {
     return x;

--- a/src/ad.js
+++ b/src/ad.js
@@ -9,7 +9,11 @@ var valueRec = function(x) {
   } else if (_.isArray(x)) {
     return _.map(x, valueRec);
   } else if (_.isObject(x) && !_.isFunction(x)) {
-    return _.mapObject(x, valueRec);
+  	// Ensure prototype chain is preserved
+  	var proto = Object.getPrototypeOf(x);
+  	var y = _.mapObject(x, valueRec);
+  	Object.setPrototypeOf(y, proto);
+  	return y;
   } else {
     return x;
   }


### PR DESCRIPTION
I noticed that when a webppl inference thunk has an object return value, `Histogram` will lose that object's prototype when stripping the object of any AD tapes. This changes ensures that prototypes are preserved.