### PR TITLE
Clean-up grunt task names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.swp
 node_modules
 npm-debug.log
-compiled/
+bundle/
 docs/_build
 docs/_static
 docs/_templates

--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -23,11 +23,11 @@ such files have been modified. A grunt task is provided that will
 monitor the file system and run the transform when any ``.ad.js``
 files are updated. Start the task with::
 
-    grunt watch
+    grunt build-watch
 
 Alternatively, the transform can be run directly with::
 
-    ./scripts/adify
+    grunt build
 
 The scope of the transform is controlled with the ``'use ad'``
 directive. If this directive appears directly after the ``'use
@@ -71,16 +71,16 @@ many of them automatically using::
 
     grunt fixjsstyle
 
-Compiling for browser
----------------------
+Browser version
+---------------
 
-To compile webppl for use in browser, run::
+To generate a version of webppl for in-browser use, run::
 
     npm install -g browserify uglifyjs
-    grunt compile
+    grunt bundle
 
-The compiled code is written to ``compiled/webppl.js`` and a minified
-version is written to ``compiled/webppl.min.js``.
+The output is written to ``bundle/webppl.js`` and a minified version
+is written to ``bundle/webppl.min.js``.
 
 Testing
 ^^^^^^^
@@ -104,11 +104,10 @@ by performing an incremental compile whenever it detects changes to
 source files. To start `watchify`_ use::
 
     npm install -g watchify
-    grunt watchify
+    grunt browserify-watch
 
-Note that `watchify`_ only updates ``compiled/webppl.js``. Before
-running the browser tests and deploying, create the minified version
-like so::
+Note that this task only updates ``bundle/webppl.js``. Before running
+the browser tests and deploying, create the minified version like so::
 
     grunt uglify
 
@@ -118,7 +117,7 @@ Packages
 Packages can also be used in the browser. For example, to include the
 ``webppl-viz`` package use::
 
-    grunt compile:path/to/webppl-viz
+    grunt bundle:path/to/webppl-viz
 
 Multiple packages can specified, separated by colons.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,8 +17,8 @@ The compiled file can be run using nodejs::
 
     node geometric.js
 
-To use webppl in web pages, include the `browserified package
-<development/workflow.html#compiling-for-browser>`_::
+To use webppl in web pages, include the `browser bundle
+<development/workflow.html#browser-version>`_::
 
     <script src="webppl.js"></script>
     <script>webppl.run(...)</script>

--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>WebPPL</title>
-    <script src="../../compiled/webppl.min.js"></script>
+    <script src="../../bundle/webppl.min.js"></script>
     <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.21.0.css">
   </head>
   <body>


### PR DESCRIPTION
This is an attempt at making grunt task names a little less confusing. (Closes #375.) The main ideas are:

1. The task which creates the browser version is now called 'bundle' rather than 'compile'. It seems to me that 'compile' is ambiguous and perhaps best avoided. (Compile for the browser, compile webppl, compile a webppl program.) 'bundle' is a name already used in our code to describe this process, and it seems fairly descriptive to me. The output directory is also changed accordingly, from `compiled` -> `bundle`.

2. The task which runs `scripts/adify` is now called 'build', since it seems very likely that at some point we'll want a build process which does more than just expand ad macros. I'm avoiding 'compile' for the reasons mentioned above.

3. Tasks that have versions which run automatically when file system changes are detected are named with a `-watch` suffix. So far we have 'build-watch' and 'browserify-watch'. (The latter isn't 'bundle-watch' because it only creates `webppl.js`, and not `webppl.min.js`.)

I've also added better descriptions for the tasks (so that `grunt --help` is more useful) and I've updated the docs.
