### PR TITLE
Make arguments work in all contexts.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -147,10 +147,10 @@ function compile(code, options) {
   var transforms = options.transforms || [
     thunkify,
     naming,
+    varargs,
     cps,
     store,
     optimize,
-    varargs,
     trampoline
   ];
 

--- a/src/transforms/varargs.js
+++ b/src/transforms/varargs.js
@@ -37,11 +37,6 @@ function getEnclosingFunctionNode() {
 
 function varargs(node) {
 
-  if (node.seenByVarargs) {
-    return node;
-  }
-  node.seenByVarargs = true;
-
   switch (node.type) {
 
     // assign 'arguments' as first statement in body, rename to make it
@@ -76,11 +71,10 @@ function varargsMain(node) {
       node, {
         enter: function(node) {
           pushFn(node);
+          return varargs(node);
         },
         leave: function(node) {
-          var ret = varargs(node);
           popFn(node);
-          return ret;
         }
       });
   return node;

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -72,7 +72,7 @@ function runNaming(test, code, newCode, expected) {
   check(test, code, newCode, expected, eval(newCode)(''));
 }
 
-var transformAstCps = compose(cps, transformAstNaming);
+var transformAstCps = compose(cps, varargs, transformAstNaming);
 function runCps(test, code, newCode, expected) {
   eval(newCode)(function(actual) {
     check(test, code, newCode, expected, actual);
@@ -90,10 +90,10 @@ function runStorepassing(test, code, newCode, expected) {
 var transformAstOptimize = compose(optimize, transformAstStorepassing);
 var runOptimize = runStorepassing;
 
-var transformAstVarargs = compose(optimize, store, cps, varargs, transformAstNaming);
-var runVarargs = runOptimize;
+var transformAstVarargs = transformAstStorepassing;
+var runVarargs = runStorepassing;
 
-var transformAstTrampoline = compose(trampoline, transformAstVarargs);
+var transformAstTrampoline = compose(trampoline, transformAstOptimize);
 
 function runTrampoline(test, code, newCode, expected) {
   var f = eval(newCode);

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -90,7 +90,7 @@ function runStorepassing(test, code, newCode, expected) {
 var transformAstOptimize = compose(optimize, transformAstStorepassing);
 var runOptimize = runStorepassing;
 
-var transformAstVarargs = compose(varargs, transformAstOptimize);
+var transformAstVarargs = compose(optimize, store, cps, varargs, transformAstNaming);
 var runVarargs = runOptimize;
 
 var transformAstTrampoline = compose(trampoline, transformAstVarargs);
@@ -658,16 +658,12 @@ var tests = {
              'foo(3, 4);'),
       expected: 4,
       runners: [runVarargsTest, runTrampolineTest] },
-    // FIXME: This test currently fails because varargs happens after
-    //        cps which introduces additional closures. To fix this,
-    //        move the varargs transform up earlier in the order of
-    //        transforms?
-    // { name: 'testVarargs4',
-    //   code: ("var bar = function(){return function(xs){return xs;}};;" +
-    //          "var foo = function(){return bar()(arguments)};" +
-    //          "foo(3, 4);"),
-    //   expected: [3, 4],
-    //   runners: [runVarargsTest, runTrampolineTest] },
+    { name: 'testVarargs4',
+      code: ('var bar = function(){return function(xs){return xs;}};;' +
+             'var foo = function(){return bar()(arguments)};' +
+             'foo(3, 4);'),
+      expected: [3, 4],
+      runners: [runVarargsTest, runTrampolineTest] },
     { name: 'testApply',
       code: ('var foo = function(x, y){return x + y};' +
              'var bar = function(){ return apply(foo, arguments); };' +


### PR DESCRIPTION
This is intended to fix #31.

As suggested in the ticket, I've moved the `varargs` transform before `cps`. I side stepped the stack overflow which results from doing this by switching the strategy used to find a node's enclosing function. Specifically, we now maintain a stack of function nodes as we traverse, rather than annotate the AST. With that, the failing test passes.

One thing I'm not sure about is whether I've done the right thing with the tests. I've changed `transformAstVarargs` so that `varargs` runs before `cps` in the var args tests, and by doing it this way I don't think I've changed any other tests. (e.g. by including the `varargs` transform in tests that previously didn't include it.) Does this seems right, or does changing the order of the transforms require us to make more substantial changes to the tests?

I'm not entirely sure whether the existing `seenByVarargs` check is necessary any more. I can't quite fathom why it was needed originally, so for now I've done the conservative thing and left it as is.

(This probably isn't top priority, but I've had it laying around for a while and figured I should clean it up and make a PR.)