### PR TITLE
Only un-lift values added to marginals when using ad

### DIFF
--- a/src/aggregation/histogram.js
+++ b/src/aggregation/histogram.js
@@ -10,7 +10,6 @@ var Histogram = function() {
 };
 
 Histogram.prototype.add = function(value) {
-  var value = ad.valueRec(value);
   var k = util.serialize(value);
   if (this.hist[k] === undefined) {
     this.hist[k] = { count: 0, val: value };

--- a/src/aggregation/map.js
+++ b/src/aggregation/map.js
@@ -12,8 +12,6 @@ var MAP = function(retainSamples) {
 };
 
 MAP.prototype.add = function(value, score) {
-  var value = ad.valueRec(value);
-  var score = ad.value(score);
   if (this.retainSamples) {
     this.samples.push({ value: value, score: score });
   }

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -258,6 +258,9 @@ module.exports = function(env) {
     assert.strictEqual(this.completeParticles.length, this.numParticles);
 
     var hist = new Histogram();
+    var addToHist = this.adRequired ?
+        function(value) { hist.add(ad.valueRec(value)); } :
+        hist.add.bind(hist);
     var logAvgW = _.first(this.completeParticles).logWeight;
 
     return util.cpsForEach(
@@ -268,10 +271,10 @@ module.exports = function(env) {
                 this.rejuvSteps,
                 kernels.sequence(
                     this.rejuvKernel,
-                    kernels.tap(function(trace) { hist.add(trace.value); })));
+                    kernels.tap(function(trace) { addToHist(trace.value); })));
             return chain(k, particle.trace);
           } else {
-            hist.add(particle.trace.value);
+            addToHist(particle.trace.value);
             return k();
           }
         }.bind(this),

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -24,8 +24,8 @@ module.exports = function(env) {
     this.rejuvKernel = kernels.parseOptions(options.rejuvKernel);
     this.rejuvSteps = options.rejuvSteps;
 
-    this.adRequired = this.rejuvKernel.adRequired;
     this.performRejuv = this.rejuvSteps > 0;
+    this.adRequired = this.performRejuv && this.rejuvKernel.adRequired;
     this.performFinalRejuv = this.performRejuv && options.finalRejuv;
     this.numParticles = options.particles;
     this.debug = options.debug;


### PR DESCRIPTION
After these changes, we only call `ad.valueRec` on values added to marginals when we're actually using ad. This is a partial fix for #389.