### PR TITLE
Enforce dirichlet bounds

### DIFF
--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -324,7 +324,7 @@ var cauchy = makeErpType({
 function sum(xs) {
   'use ad';
   return xs.reduce(function(a, b) { return a + b; }, 0);
-};
+}
 
 
 var discrete = makeErpType({
@@ -716,19 +716,33 @@ var poisson = makeErpType({
   }
 });
 
-
 function dirichletSample(alpha) {
+  var n = alpha.length;
+
   var ssum = 0;
   var theta = [];
   var t;
-  for (var i = 0; i < alpha.length; i++) {
+  for (var i = 0; i < n; i++) {
     t = gammaSample(alpha[i], 1);
     theta[i] = t;
     ssum = ssum + t;
   }
-  for (var j = 0; j < theta.length; j++) {
+
+  var numUnderflowCorrections = 0;
+  for (var j = 0; j < n; j++) {
     theta[j] /= ssum;
+    if (theta[j] === 0) {
+      theta[j] = Number.EPSILON;
+      numUnderflowCorrections += 1;
+    }
   }
+
+  for (var k = 0; k < n; k++) {
+    if (theta[k] === 1) {
+      theta[k] -= Number.EPSILON * numUnderflowCorrections;
+    }
+  }
+
   return theta;
 }
 

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -150,8 +150,8 @@ function makeErpType(options) {
   // output of `console.log` when it's called on an ERP that uses the
   // default constructor.
   var erp = _.has(options, 'constructor') ?
-        options.constructor :
-        function(params) { this.params = params; };
+      options.constructor :
+      function(params) { this.params = params; };
 
   erp.prototype = Object.create(options.parent.prototype);
   erp.prototype.constructor = erp;
@@ -314,7 +314,9 @@ var cauchy = makeErpType({
   },
   score: function(x) {
     'use ad';
-    return -LOG_PI - Math.log(this.params.scale) - Math.log(1 + Math.pow((x - this.params.location) / this.params.scale, 2));
+    var scale = this.params.scale;
+    var location = this.params.location;
+    return -LOG_PI - Math.log(scale) - Math.log(1 + Math.pow((x - location) / scale, 2));
   }
 });
 
@@ -436,7 +438,9 @@ var gamma = makeErpType({
   },
   score: function(x) {
     'use ad';
-    return (this.params.shape - 1) * Math.log(x) - x / this.params.scale - logGamma(this.params.shape) - this.params.shape * Math.log(this.params.scale);
+    var shape = this.params.shape;
+    var scale = this.params.scale;
+    return (shape - 1) * Math.log(x) - x / scale - logGamma(shape) - shape * Math.log(scale);
   },
   support: function() {
     return { lower: 0, upper: Infinity };
@@ -477,8 +481,11 @@ var beta = makeErpType({
   },
   score: function(x) {
     'use ad';
+    var a = this.params.a;
+    var b = this.params.b;
+
     return ((x > 0 && x < 1) ?
-            (this.params.a - 1) * Math.log(x) + (this.params.b - 1) * Math.log(1 - x) - logBeta(this.params.a, this.params.b) :
+            (a - 1) * Math.log(x) + (b - 1) * Math.log(1 - x) - logBeta(a, b) :
             -Infinity);
   },
   support: function() {
@@ -584,7 +591,7 @@ function zeros(n) {
 }
 
 function multinomialSample(theta, n) {
-  var thetaSum = util.sum(theta);
+  // var thetaSum = util.sum(theta);
   var a = zeros(theta.length);
   for (var i = 0; i < n; i++) {
     a[discreteSample(theta)]++;
@@ -605,7 +612,7 @@ var multinomial = makeErpType({
     }
     var x = [];
     var y = [];
-    for (var i = 0; i < this.params.ps.length; i++){
+    for (var i = 0; i < this.params.ps.length; i++) {
       x[i] = lnfact(val[i]);
       y[i] = val[i] * Math.log(this.params.ps[i]);
     }
@@ -638,12 +645,12 @@ function buildHistogramFromCombinations(samples, states) {
   var stateIndices = _.range(states.length);
   // Build default histogram that has 0 for all state indices
   var zeroHist = (_.chain(stateIndices)
-                   .map(function(i){return [i, 0];})
-                   .object()
-                   .value());
+      .map(function(i) {return [i, 0];})
+      .object()
+      .value());
   // Now build actual histogram, keeping 0s for unsampled states
   var hist = _.defaults(_.countBy(samples), zeroHist);
-  var array = _.sortBy(hist, function(val, key){ return key; });
+  var array = _.sortBy(hist, function(val, key) { return key; });
   return array;
 }
 
@@ -819,9 +826,9 @@ var marginal = makeErpType({
   },
   print: function() {
     return _.map(this.params.dist, function(obj, val) { return [val, obj.prob]; })
-      .sort(function(a, b) { return b[1] - a[1]; })
-      .map(function(pair) { return '    ' + pair[0] + ' : ' + pair[1]; })
-      .join('\n');
+        .sort(function(a, b) { return b[1] - a[1]; })
+        .map(function(pair) { return '    ' + pair[0] + ' : ' + pair[1]; })
+        .join('\n');
   }
 });
 

--- a/src/erp.ad.js
+++ b/src/erp.ad.js
@@ -722,27 +722,23 @@ function dirichletSample(alpha) {
   var ssum = 0;
   var theta = [];
   var t;
+  // sample n gammas
   for (var i = 0; i < n; i++) {
     t = gammaSample(alpha[i], 1);
     theta[i] = t;
     ssum = ssum + t;
   }
 
-  var numUnderflowCorrections = 0;
+  // normalize and catch under/overflow
   for (var j = 0; j < n; j++) {
     theta[j] /= ssum;
     if (theta[j] === 0) {
-      theta[j] = Number.EPSILON;
-      numUnderflowCorrections += 1;
+      theta[j] = Number.EPSILON
+    }
+    if (theta[j] === 1) {
+      theta[j] = 1 - Number.EPSILON
     }
   }
-
-  for (var k = 0; k < n; k++) {
-    if (theta[k] === 1) {
-      theta[k] -= Number.EPSILON * numUnderflowCorrections;
-    }
-  }
-
   return theta;
 }
 
@@ -902,6 +898,7 @@ module.exports = {
   discreteSample: discreteSample,
   gaussianSample: gaussianSample,
   gammaSample: gammaSample,
+  dirichletSample: dirichletSample,
   // helpers
   serialize: serialize,
   deserialize: deserialize,


### PR DESCRIPTION
Currently, `dirichletSample` can return values that are outside the support, e.g., `[0,1]`. This happens because `dirichletSample` works by sampling n Gammas and normalizing. Gamma sampling might underflow; we actually catch this inside `gammaSample` and replace 0 with `Number.MIN_VALUE`, but this isn't enough because those values get further divided when we normalize, so they become 0 again.

This PR corrects for underflow.

A couple remarks:

1. We currently don't work hard to ensure that Dirichlet samples sum to 1 and this PR continues that "tradition" (e.g., here, we correct `[0, 0, 1]` to `[ϵ, ϵ, 1-2ϵ]` but we don't correct `[0, 0.5, 0.5]` to `[ϵ, 0.5-ϵ/2, 0.5-ϵ/2]`).
2. We could further mitigate gamma underflow by switching to `expGammaSample` (a [la my proposal from a few months ago](https://github.com/probmods/webppl/pull/277#issuecomment-165332720)) but some informal testing suggested that this doesn't result in the right marginals for `dirichletDriftERP`, so I'll need to investigate more before switching.