### PR TITLE
Consistent coroutine interface

### DIFF
--- a/examples/geometric.wppl
+++ b/examples/geometric.wppl
@@ -4,4 +4,4 @@ var geometric = function(p) {
 
 Enumerate(
     function() {return geometric(0.5);},
-    10);
+    {maxExecutions: 10});

--- a/examples/hmmIncremental.wppl
+++ b/examples/hmmIncremental.wppl
@@ -25,4 +25,4 @@ var hmm = function(n) {
 Enumerate(function() {
   var r = hmm(3)
   return r.states
-}, 100)
+}, {maxExecutions: 100})

--- a/examples/hmmSampleWithFactor.wppl
+++ b/examples/hmmSampleWithFactor.wppl
@@ -26,4 +26,4 @@ var hmm = function(n) {
 Enumerate(function() {
   var r = hmm(3)
   return r.states
-}, 500)
+}, {maxExecutions: 500})

--- a/examples/pcfg.wppl
+++ b/examples/pcfg.wppl
@@ -39,4 +39,4 @@ Enumerate(function() {
   var y = pcfg('start')
   factor(arrayEq(y.slice(0, 2), ['tall', 'John']) ? 0 : -Infinity) //yield starts with "tall John"
   return y[2] ? y[2] : '' //distribution on next word?
-}, 300)
+}, {maxExecutions: 300})

--- a/examples/pcfgIncremental.wppl
+++ b/examples/pcfgIncremental.wppl
@@ -43,4 +43,4 @@ var expand = function(symbols, yieldsofar, trueyield) {
 Enumerate(function() {
   var y = pcfg('start', [], ['tall', 'John'])
   return y[2] ? y[2] : '' //distribution on next word?
-}, 300)
+}, {maxExecutions: 300})

--- a/examples/pragmaticsWithSemanticParsing.wppl
+++ b/examples/pragmaticsWithSemanticParsing.wppl
@@ -153,7 +153,7 @@ var literalListener = cache(function(utterance) {
     var world = worldPrior(2, m)
     factor(m(world) ? 0 : -Infinity)
     return world
-  }, 100)
+  }, {maxExecutions: 100})
 })
 
 var speaker = cache(function(world) {
@@ -162,7 +162,7 @@ var speaker = cache(function(world) {
     var L = literalListener(utterance)
     factor(L.score(world))
     return utterance
-  }, 100)
+  }, {maxExecutions: 100})
 })
 
 var listener = function(utterance) {
@@ -172,7 +172,7 @@ var listener = function(utterance) {
     var S = speaker(world)
     factor(S.score(utterance))
     return isall(world)
-  }, 100)
+  }, {maxExecutions: 100})
 }
 
 listener('some of the blond people are nice')

--- a/src/inference/asyncpf.js
+++ b/src/inference/asyncpf.js
@@ -38,9 +38,9 @@ module.exports = function(env) {
     };
   }
 
-  function AsyncPF(s, k, a, wpplFn, numParticles, bufferSize) {
+  function AsyncPF(s, k, a, wpplFn, options) {
     this.numParticles = 0;      // K_0 -- initialized here, set in run
-    this.bufferSize = bufferSize == undefined ? numParticles : bufferSize; // \rho
+    this.bufferSize = options.bufferSize == undefined ? options.particles : options.bufferSize; // \rho
     this.initNumParticles = Math.floor(this.bufferSize * (1 / 2));         // \rho_0
     this.exitK = function(s) {return wpplFn(s, env.exit, a);};
     this.store = s;
@@ -196,8 +196,9 @@ module.exports = function(env) {
 
   AsyncPF.prototype.incrementalize = env.defaultCoroutine.incrementalize;
 
-  function asyncPF(s, cc, a, wpplFn, numParticles, bufferSize) {
-    return new AsyncPF(s, cc, a, wpplFn, numParticles, bufferSize).run(numParticles);
+  function asyncPF(s, cc, a, wpplFn, options) {
+    options = options || {};
+    return new AsyncPF(s, cc, a, wpplFn, options).run(options.particles);
   }
 
   return {

--- a/src/inference/asyncpf.js
+++ b/src/inference/asyncpf.js
@@ -39,6 +39,7 @@ module.exports = function(env) {
   }
 
   function AsyncPF(s, k, a, wpplFn, options) {
+    util.throwUnlessOpts(options, 'AsyncPF');
     this.numParticles = 0;      // K_0 -- initialized here, set in run
     this.bufferSize = options.bufferSize == undefined ? options.particles : options.bufferSize; // \rho
     this.initNumParticles = Math.floor(this.bufferSize * (1 / 2));         // \rho_0

--- a/src/inference/enumerate.ad.js
+++ b/src/inference/enumerate.ad.js
@@ -15,6 +15,7 @@ var ScoreAggregator = require('../aggregation/ScoreAggregator');
 module.exports = function(env) {
 
   function Enumerate(store, k, a, wpplFn, options, Q) {
+    util.throwUnlessOpts(options, 'Enumerate');
     options = util.mergeDefaults(options, {
       maxExecutions: Infinity
     });

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -756,8 +756,9 @@ module.exports = function(env) {
 
   // ------------------------------------------------------------------
 
-  function IncrementalMH(s, k, a, wpplFn, numSamples, opts) {
+  function IncrementalMH(s, k, a, wpplFn, opts) {
     // Extract options
+    var numSamples = opts.samples === undefined ? 1 : opts.samples;
     var dontAdapt = opts.dontAdapt === undefined ? false : opts.dontAdapt;
     var debuglevel = opts.debuglevel === undefined ? 0 : opts.debuglevel;
     var verbose = opts.verbose === undefined ? false : opts.verbose;
@@ -1094,9 +1095,9 @@ module.exports = function(env) {
 
   // ------------------------------------------------------------------
 
-  function imh(s, cc, a, wpplFn, numSamples, opts) {
+  function imh(s, cc, a, wpplFn, opts) {
     opts = opts || {};
-    return new IncrementalMH(s, cc, a, wpplFn, numSamples, opts).run();
+    return new IncrementalMH(s, cc, a, wpplFn, opts).run();
   }
 
   return {

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -756,7 +756,7 @@ module.exports = function(env) {
 
   // ------------------------------------------------------------------
 
-  function IncrementalMH(s, k, a, wpplFn, numIterations, opts) {
+  function IncrementalMH(s, k, a, wpplFn, numSamples, opts) {
     // Extract options
     var dontAdapt = opts.dontAdapt === undefined ? false : opts.dontAdapt;
     var debuglevel = opts.debuglevel === undefined ? 0 : opts.debuglevel;
@@ -781,7 +781,7 @@ module.exports = function(env) {
 
     this.k = k;
     this.oldStore = s;
-    this.iterations = numIterations;
+    this.iterations = numSamples * (lag + 1) + burn;
     this.wpplFn = wpplFn;
     this.s = s;
     this.a = a;
@@ -790,7 +790,7 @@ module.exports = function(env) {
         new MaxAggregator(justSample) :
         new CountAggregator();
 
-    this.totalIterations = numIterations;
+    this.totalIterations = this.iterations;
     this.acceptedProps = 0;
     this.lag = lag;
     this.burn = burn;
@@ -913,7 +913,7 @@ module.exports = function(env) {
         debuglog(1, 'return val:', val);
 
         // Record this sample, if lag allows for it and not in burnin period
-        if ((iternum % (this.lag + 1) === 0) && (iternum > this.burn)) {
+        if ((iternum % (this.lag + 1) === 0) && (iternum >= this.burn)) {
           // Replace val with accumulated query, if need be.
           if (val === env.query)
             val = this.query.getTable();
@@ -1094,9 +1094,9 @@ module.exports = function(env) {
 
   // ------------------------------------------------------------------
 
-  function imh(s, cc, a, wpplFn, numIters, opts) {
+  function imh(s, cc, a, wpplFn, numSamples, opts) {
     opts = opts || {};
-    return new IncrementalMH(s, cc, a, wpplFn, numIters, opts).run();
+    return new IncrementalMH(s, cc, a, wpplFn, numSamples, opts).run();
   }
 
   return {

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -757,6 +757,7 @@ module.exports = function(env) {
   // ------------------------------------------------------------------
 
   function IncrementalMH(s, k, a, wpplFn, opts) {
+    util.throwUnlessOpts(opts, 'IncrementalMH');
     // Extract options
     var numSamples = opts.samples === undefined ? 1 : opts.samples;
     var dontAdapt = opts.dontAdapt === undefined ? false : opts.dontAdapt;

--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -12,6 +12,7 @@ module.exports = function(env) {
   var kernels = require('./kernels')(env);
 
   function MCMC(s, k, a, wpplFn, options) {
+    util.throwUnlessOpts(options, 'MCMC');
     var options = util.mergeDefaults(options, {
       samples: 100,
       kernel: 'MH',

--- a/src/inference/pmcmc.js
+++ b/src/inference/pmcmc.js
@@ -16,6 +16,7 @@ module.exports = function(env) {
 
 
   function PMCMC(s, cc, a, wpplFn, options) {
+    util.throwUnlessOpts(options, 'PMCMC');
     // Move old coroutine out of the way and install this as the
     // current handler.
     this.oldCoroutine = env.coroutine;

--- a/src/inference/pmcmc.js
+++ b/src/inference/pmcmc.js
@@ -14,8 +14,8 @@ module.exports = function(env) {
     return xs[xs.length - 1];
   }
 
-  function PMCMC(s, cc, a, wpplFn, numParticles, numSweeps) {
 
+  function PMCMC(s, cc, a, wpplFn, options) {
     // Move old coroutine out of the way and install this as the
     // current handler.
     this.oldCoroutine = env.coroutine;
@@ -29,11 +29,11 @@ module.exports = function(env) {
     // Setup inference variables
     this.particleIndex = 0;  // marks the active particle
     this.retainedParticle = undefined;
-    this.numSweeps = numSweeps;
+    this.numSweeps = options.sweeps;
     this.sweep = 0;
     this.wpplFn = wpplFn;
     this.address = a;
-    this.numParticles = numParticles;
+    this.numParticles = options.particles;
     this.resetParticles();
     this.hist = new CountAggregator();
   }
@@ -197,8 +197,8 @@ module.exports = function(env) {
 
   PMCMC.prototype.incrementalize = env.defaultCoroutine.incrementalize;
 
-  function pmc(s, cc, a, wpplFn, numParticles, numSweeps) {
-    return new PMCMC(s, cc, a, wpplFn, numParticles, numSweeps).run();
+  function pmc(s, cc, a, wpplFn, options) {
+    return new PMCMC(s, cc, a, wpplFn, options).run();
   }
 
   return {

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -16,6 +16,7 @@ var CountAggregator = require('../aggregation/CountAggregator');
 module.exports = function(env) {
 
   function Rejection(s, k, a, wpplFn, options) {
+    util.throwUnlessOpts(options, 'Rejection');
     options = util.mergeDefaults(options, {
       samples: 1,
       maxScore: 0,

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -15,19 +15,24 @@ var CountAggregator = require('../aggregation/CountAggregator');
 
 module.exports = function(env) {
 
-  function Rejection(s, k, a, wpplFn, numSamples, maxScore, incremental) {
+  function Rejection(s, k, a, wpplFn, options) {
+    options = util.mergeDefaults(options, {
+      samples: 1,
+      maxScore: 0,
+      incremental: false
+    });
+    this.numSamples = options.samples;
+    this.maxScore = options.maxScore;
+    this.incremental = options.incremental;
     this.s = s;
     this.k = k;
     this.a = a;
     this.wpplFn = wpplFn;
-    this.maxScore = (maxScore === undefined) ? 0 : maxScore;
-    this.incremental = incremental;
     this.hist = new CountAggregator();
-    this.numSamples = (numSamples === undefined) ? 1 : numSamples;
     this.oldCoroutine = env.coroutine;
     env.coroutine = this;
 
-    if (!_.isNumber(numSamples) || numSamples <= 0) {
+    if (!_.isNumber(this.numSamples) || this.numSamples <= 0) {
       throw 'numSamples should be a positive integer.';
     }
 
@@ -82,8 +87,8 @@ module.exports = function(env) {
 
   Rejection.prototype.incrementalize = env.defaultCoroutine.incrementalize;
 
-  function rej(s, k, a, wpplFn, numSamples, maxScore, incremental) {
-    return new Rejection(s, k, a, wpplFn, numSamples, maxScore, incremental).run();
+  function rej(s, k, a, wpplFn, options) {
+    return new Rejection(s, k, a, wpplFn, options).run();
   }
 
   return {

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -14,6 +14,7 @@ module.exports = function(env) {
   var kernels = require('./kernels')(env);
 
   function SMC(s, k, a, wpplFn, options) {
+    util.throwUnlessOpts(options, 'SMC');
     var options = util.mergeDefaults(options, {
       particles: 100,
       rejuvSteps: 0,

--- a/src/util.js
+++ b/src/util.js
@@ -179,6 +179,13 @@ function mergeDefaults(options, defaults) {
   return _.defaults(options ? _.clone(options) : {}, defaults);
 }
 
+function throwUnlessOpts(options, fnName) {
+  assert.ok(fnName);
+  if (options !== undefined && !_.isObject(options)) {
+    throw fnName + ' expected an options object but received: ' + JSON.stringify(options);
+  }
+}
+
 function InfToJSON(k, v) {
   if (v === Infinity) {
     return 'Infinity';
@@ -255,6 +262,7 @@ module.exports = {
   prettyJSON: prettyJSON,
   runningInBrowser: runningInBrowser,
   mergeDefaults: mergeDefaults,
+  throwUnlessOpts: throwUnlessOpts,
   sum: sum,
   product: product,
   asArray: asArray,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -15,18 +15,18 @@ var tests = [
     name: 'ForwardSample',
     func: 'Rejection',
     settings: {
-      args: [3000],
+      args: { samples: 3000 },
       hist: { tol: 0.05 },
       mean: { tol: 0.2 },
       std: { tol: 0.2 }
     },
     models: {
-      deterministic: { args: [10], hist: { tol: 0 } },
+      deterministic: { args: { samples: 10 }, hist: { tol: 0 } },
       flips: true,
       geometric: true,
       randomInteger: true,
-      gaussian: { args: [10000] },
-      uniform: { args: [10000] },
+      gaussian: { args: { samples: 10000 } },
+      uniform: { args: { samples: 10000 } },
       beta: true,
       exponential: true,
       binomial: true,
@@ -44,7 +44,7 @@ var tests = [
   {
     name: 'Enumerate',
     settings: {
-      args: [],
+      args: {},
       MAP: { check: true }
     },
     models: {
@@ -53,7 +53,7 @@ var tests = [
       incrementalBinomial: true,
       deterministic: { hist: { exact: true } },
       store: { hist: { exact: true } },
-      geometric: { args: [10] },
+      geometric: { args: { maxExecutions: 10 } },
       cache: true,
       withCaching: true,
       earlyExit: { hist: { exact: true } },
@@ -64,21 +64,21 @@ var tests = [
   {
     name: 'IncrementalMH',
     settings: {
-      args: [5000],
+      args: { samples: 5000 },
       hist: { tol: 0.1 }
       //MAP: { tol: 0.15, check: true }
     },
     models: {
       simple: true,
-      deterministic: { hist: { tol: 0 }, args: [100] },
+      deterministic: { hist: { tol: 0 }, args: { samples: 100 } },
       cache: true,
-      store: { hist: { tol: 0 }, args: [100] },
+      store: { hist: { tol: 0 }, args: { samples: 100 } },
       geometric: true,
-      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [100000] },
+      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { samples: 100000 } },
       withCaching: true,
       variableSupport: true,
       query: true,
-      onlyMAP: { mean: { tol: 0.1 }, args: [150, { onlyMAP: true }] },
+      onlyMAP: { mean: { tol: 0.1 }, args: { samples: 150, onlyMAP: true } },
       nestedEnum1: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
       nestedEnum2: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
       nestedEnum3: { mean: { tol: 0.1 }, std: { tol: 0.075 } },
@@ -94,7 +94,7 @@ var tests = [
     name: 'IMHjustSample',
     func: 'IncrementalMH',
     settings: {
-      args: [100, { justSample: true }]
+      args: { samples: 100, justSample: true }
     },
     models: {
       deterministic: { hist: { tol: 0 } }
@@ -103,46 +103,46 @@ var tests = [
   {
     name: 'PMCMC',
     settings: {
-      args: [1000, 5],
+      args: { particles: 1000, sweeps: 5 },
       hist: { tol: 0.1 },
       MAP: { tol: 0.15, check: true }
     },
     models: {
       simple: true,
       cache: true,
-      deterministic: { hist: { tol: 0 }, args: [30, 30] },
-      store: { hist: { tol: 0 }, args: [30, 30] },
-      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [1000, 100] },
+      deterministic: { hist: { tol: 0 }, args: { particles: 30, sweeps: 30 } },
+      store: { hist: { tol: 0 }, args: { particles: 30, sweeps: 30 } },
+      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { particles: 1000, sweeps: 100 } },
       withCaching: true
     }
   },
   {
     name: 'AsyncPF',
     settings: {
-      args: [1000, 1000],
+      args: { particles: 1000, bufferSize: 1000 },
       hist: { tol: 0.1 },
       logZ: { check: true, tol: 0.1 },
       MAP: { tol: 0.15, check: true }
     },
     models: {
       simple: true,
-      store: { hist: { tol: 0 }, args: [100, 100] },
-      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: [10000, 1000] },
+      store: { hist: { tol: 0 }, args: { particles: 100, bufferSize: 100 } },
+      gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { particles: 10000, bufferSize: 1000 } },
       withCaching: true
     }
   },
   {
     name: 'Rejection',
     settings: {
-      args: [1000],
+      args: { samples: 1000 },
       hist: { tol: 0.1 }
     },
     models: {
       simple: true,
       cache: true,
       deterministic: { hist: { tol: 0 } },
-      upweight: { args: [1000, 10] },
-      incrementalBinomial: { args: [1000, -2] },
+      upweight: { args: { samples: 1000, maxScore: 10 } },
+      incrementalBinomial: { args: { samples: 1000, maxScore: -2 } },
       store: { hist: { tol: 0 } },
       geometric: true,
       varFactors1: true,
@@ -164,13 +164,13 @@ var tests = [
     name: 'IncrementalRejection',
     func: 'Rejection',
     settings: {
-      args: [1000, 0, true],
+      args: { samples: 1000, incremental: true },
       hist: { tol: 0.1 }
     },
     models: {
       simple: true,
       cache: true,
-      incrementalBinomial: { args: [1000, -2, true] },
+      incrementalBinomial: { args: { samples: 1000, maxScore: -2, incremental: true } },
       store: { hist: { tol: 0 } },
       geometric: true,
       varFactors2: true


### PR DESCRIPTION
This PR makes the interface to inference coroutines more consistent.

* All inference coroutines now have the interface `Method(thunk, options)`.
* `IncrementalMH` takes the number of `samples` rather than number of `iterations`. This matches `MCMC`.

If the coroutines are called with something other than an options object as the second arg, a sensible error message is shown.

The main motivation for this change is that it simplifies the implementation of #86.

I've not updated the documentation as part of this PR, I'll do that as part of #86.

