### PR TITLE
Add `Infer` function

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -1,57 +1,74 @@
 Inference
 =========
 
+.. js:function:: Infer(thunk, options)
+
+   :param function thunk: Program to perform inference in.
+   :param object options: Inference options.
+
+``Infer`` computes the marginal distribution on return values of a
+program. The program is specified as a function of zero arguments,
+also known as a `thunk`.
+
+The inference algorithm to use must be specified using the ``method``
+option. For example::
+
+  Infer(thunk, {method: 'Enumerate'})
+
+The following algorithms are available:
+
 Enumeration
 -----------
 
-.. js:function:: Enumerate(thunk[, maxExecutions])
+.. js:function:: Infer(thunk, {method: 'Enumerate'[, ...]})
 
-   :param function thunk: Program to perform inference in.
-   :param number maxExecutions: Maximum number of (complete) executions to enumerate.
-   :returns: Marginal ERP
+   This method performs inference by enumeration.
 
-   This method performs inference by enumeration. If ``maxExecutions``
-   is not specified, exhaustive enumeration is performed. Otherwise,
-   paths through the program are explored using a "most probable first"
-   heuristic until the maximum number of executions is reached.
+   The following options are supported:
 
-   Alternative search strategies are available using the following
-   methods:
+   .. describe:: maxExecutions
 
-   * :js:func:`EnumerateBreadthFirst`
-   * :js:func:`EnumerateDepthFirst`
-   * :js:func:`EnumerateLikelyFirst`.
+      Maximum number of (complete) executions to enumerate.
+
+   If ``maxExecutions`` is not specified, exhaustive enumeration is
+   performed. Otherwise, paths through the program are explored using
+   a "most probable first" heuristic until the maximum number of
+   executions is reached.
+
+   Alternatively, the search strategy can be specified explicitly
+   using the ``EnumerateBreadthFirst``, ``EnumerateDepthFirst`` or
+   ``EnumerateLikelyFirst`` methods.
 
    Example usage::
 
-     Enumerate(model, 10);
-
-.. js:function:: EnumerateBreadthFirst(thunk[, maxExecutions])
-
-   See :js:func:`Enumerate`
-
-.. js:function:: EnumerateDepthFirst(thunk[, maxExecutions])
-
-   See :js:func:`Enumerate`
-
-.. js:function:: EnumerateLikelyFirst(thunk[, maxExecutions])
-
-   See :js:func:`Enumerate`
+     Infer(thunk, {method: 'Enumerate', maxExecutions: 10});
+     Infer(thunk, {method: 'EnumerateBreadthFirst'});
 
 Rejection Sampling
 ------------------
 
-.. js:function:: Rejection(thunk, numSamples[, maxScore, incremental])
-
-   :param function thunk: Program to perform inference in.
-   :param number numSamples: The number of samples to take.
-   :param number maxScore: An upper bound on the total factor score
-                           per-execution. Only required for
-                           incremental mode.
-   :param boolean incremental: Enable incremental mode. Default: ``false``.
-   :returns: Marginal ERP
+.. js:function:: Infer(thunk, {method: 'Rejection'[, ...]})
 
    This method performs inference using rejection sampling.
+
+   The following options are supported:
+
+   .. describe:: samples
+
+      The number of samples to take.
+
+      Default: ``1``
+
+   .. describe:: maxScore
+
+      An upper bound on the total factor score per-execution. Only
+      required for incremental mode.
+
+   .. describe:: incremental
+
+      Enable incremental mode.
+
+      Default: ``false``
 
    Incremental mode improves efficiency by rejecting samples before
    execution reaches the end of the program where possible. This
@@ -63,16 +80,12 @@ Rejection Sampling
 
    Example usage::
 
-     Rejection(model, 100);
+     Infer(thunk, {method: 'Rejection', samples: 100});
 
 MCMC
 ----
 
-.. js:function:: MCMC(thunk[, options])
-
-   :param function thunk: Program to perform inference in.
-   :param object options: Options.
-   :returns: Marginal ERP
+.. js:function:: Infer(thunk, {method: 'MCMC'[, ...]})
 
    This method performs inference using Markov chain Monte Carlo.
 
@@ -129,7 +142,7 @@ MCMC
 
    Example usage::
 
-     MCMC(model, { samples: 1000, lag: 100, burn: 5 });
+     Infer(thunk, {samples: 1000, lag: 100, burn: 5});
 
 Kernels
 ^^^^^^^
@@ -142,7 +155,7 @@ The following kernels are available:
 
 Example usage::
 
-    MCMC(model, { kernel: 'MH' });
+    Infer(thunk, {method: 'MCMC', kernel: 'MH'});
 
 .. describe:: HMC
 
@@ -168,34 +181,35 @@ Example usage::
 
 Example usage::
 
-    MCMC(model, { kernel: 'HMC' });
-    MCMC(model, { kernel: { HMC: { steps: 10, stepSize: 1 }}});
+    Infer(thunk, {method: 'MCMC', kernel: 'HMC'});
+    Infer(thunk, {method: 'MCMC', kernel: {HMC: {steps: 10, stepSize: 1}}});
 
 Incremental MH
 --------------
 
-.. js:function:: IncrementalMH(thunk, numIterations[, options])
+.. js:function:: Infer(thunk, {method: 'IncrementalMH'[, ...]})
 
-   :param function thunk: Program to perform inference in.
-   :param number numIterations: The total number of iterations to
-                                perform. (Including burn-in and lag.)
-   :param object options: Options.
-   :returns: Marginal ERP
-
-   This method performs inference using C3. [ritchie15]_ 
+   This method performs inference using C3. [ritchie15]_
 
    The following options are supported:
 
+      .. describe:: samples
+
+         The number of samples to take.
+
+         Default: ``100``
+
       .. describe:: lag
 
-         The number of iterations to perform before collecting
+         The number of additional iterations to perform between
          samples.
 
          Default: ``0``
 
       .. describe:: burn
 
-         The number of iterations to perform between samples.
+         The number of additional iterations to perform before
+         collecting samples.
 
          Default: ``0``
 
@@ -224,7 +238,7 @@ Incremental MH
 
    Example usage::
 
-     IncrementalMH(model, 100, { lag: 5, burn: 10 });
+     Infer(thunk, {method: 'IncrementalMH', samples: 100, lag: 5, burn: 10});
 
    To maximize efficiency when inferring marginals over multiple variables, use the ``query`` table, rather than building up a list of variable values::
 
@@ -242,7 +256,7 @@ Incremental MH
         hmm(100, observed_data);
         return query;
       }
-      IncrementalMH(model, 100, { lag: 5, burn: 10 });
+      Infer(model, {method: 'IncrementalMH', samples: 100, lag: 5, burn: 10});
 
    ``query`` is a write-only table which can be returned from a program (and thus marginalized). The only operation it supports is adding named values:
 
@@ -256,11 +270,7 @@ Incremental MH
 SMC
 ---
 
-.. js:function:: SMC(thunk[, options])
-
-   :param function thunk: Program to perform inference in.
-   :param object options: Options.
-   :returns: Marginal ERP
+.. js:function:: Infer(thunk, {method: 'SMC'[, ...]})
 
    This method performs inference using sequential Monte Carlo. When
    ``rejuvSteps`` is 0, this method is also known as a particle
@@ -290,7 +300,7 @@ SMC
 
    Example usage::
 
-     SMC(model, { particles: 100, rejuvSteps: 5 });
+     Infer(thunk, {method: 'SMC', particles: 100, rejuvSteps: 5});
 
 .. rubric:: Bibliography
 

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -669,3 +669,12 @@ var ParticleFilter = function(wpplFn, particles) {
 var ParticleFilterRejuv = function(wpplFn, particles, rejuvSteps) {
   return SMC(wpplFn, { particles: particles, rejuvSteps: rejuvSteps });
 };
+
+var Infer = function(wpplFn, options) {
+  assert.ok(_.isObject(options), 'Infer: options argument not given.');
+  var methodName = options.method;
+  assert.ok(methodName, 'Infer: the option \'method\' must be specified.');
+  assert.ok(_.has(_top, methodName), 'Infer: unknown method \'' + methodName + '\'.');
+  var method = _top[methodName];
+  return method(wpplFn, _.omit(options, 'method'));
+};

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -34,7 +34,7 @@ module.exports = function(env) {
     env.coroutine = this;
 
     if (!_.isNumber(this.numSamples) || this.numSamples <= 0) {
-      throw 'numSamples should be a positive integer.';
+      throw 'samples should be a positive integer.';
     }
 
     if (this.incremental) {

--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,8 @@ function compile(code, options) {
     var macros = _.chain(bundles).pluck('macros').flatten().uniq().value();
     var programAst = parse(code, macros, options.filename);
     var asts = _.pluck(bundles, 'ast').map(copyAst).concat(programAst);
-    var doCaching = _.any(asts, caching.transformRequired);
+    assert.strictEqual(bundles[0].filename, 'header.wppl');
+    var doCaching = _.any(asts.slice(1), caching.transformRequired);
 
     if (options.verbose && doCaching) {
       console.log('Caching transform will be applied.');

--- a/src/transforms/caching.js
+++ b/src/transforms/caching.js
@@ -67,11 +67,23 @@ function cachingMain(node) {
   return estraverse.replace(node, { leave: exit });
 }
 
+
+function isImhIdentifier(node) {
+  return node.type === 'Identifier' && node.name === 'IncrementalMH';
+}
+
+function isImhInferMethodOption(node) {
+  return node.type === 'Property' &&
+      ((node.key.type === 'Identifier' && node.key.name === 'method') ||
+      (node.key.type === 'Literal' && node.key.value === 'method')) &&
+      (node.value.type === 'Literal' && node.value.value === 'IncrementalMH');
+}
+
 function transformRequired(programAST) {
   var flag = false;
   estraverse.traverse(programAST, {
     enter: function(node) {
-      if (node.type === 'Identifier' && node.name === 'IncrementalMH') {
+      if (isImhIdentifier(node) || isImhInferMethodOption(node)) {
         flag = true;
         this.break();
       }

--- a/tests/test-caching.js
+++ b/tests/test-caching.js
@@ -15,7 +15,13 @@ var hasCachingDirectiveTests = {
 
 var transformRequiredTests = {
   test1: { code: 'IncrementalMH(model, 0);', expected: true },
-  test2: { code: 'Enumerate(model);', expected: false }
+  test2: { code: 'Enumerate(model);', expected: false },
+  test3: { code: 'Infer(model, {method: "IncrementalMH"});', expected: true },
+  test4: { code: 'Infer(model, {method: "Enumerate"});', expected: false },
+  test5: { code: '({method: "IncrementalMH"})', expected: true },
+  test6: { code: '({method: "Enumerate"})', expected: false },
+  test7: { code: '({"method": "IncrementalMH"})', expected: true },
+  test8: { code: '({"method": "Enumerate"})', expected: false }
 };
 
 function generateTests(cases, testFn) {

--- a/tests/test-data/stochastic/models/withCaching.wppl
+++ b/tests/test-data/stochastic/models/withCaching.wppl
@@ -1,4 +1,4 @@
-var _ = IncrementalMH; // Trigger caching transforms.
+var imh = IncrementalMH; // Trigger caching transforms.
 var f = function() {};
 
 var model = function() {

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -13,7 +13,7 @@ var testDataDir = './tests/test-data/stochastic/';
 var tests = [
   {
     name: 'ForwardSample',
-    func: 'Rejection',
+    method: 'Rejection',
     settings: {
       args: { samples: 3000 },
       hist: { tol: 0.05 },
@@ -92,7 +92,7 @@ var tests = [
   },
   {
     name: 'IMHjustSample',
-    func: 'IncrementalMH',
+    method: 'IncrementalMH',
     settings: {
       args: { samples: 100, justSample: true }
     },
@@ -162,7 +162,7 @@ var tests = [
   },
   {
     name: 'IncrementalRejection',
-    func: 'Rejection',
+    method: 'Rejection',
     settings: {
       args: { samples: 1000, incremental: true },
       hist: { tol: 0.1 }
@@ -178,7 +178,7 @@ var tests = [
   },
   {
     name: 'ParticleFilter',
-    func: 'SMC',
+    method: 'SMC',
     settings: {
       hist: { tol: 0.1 },
       logZ: { check: true, tol: 0.1 },
@@ -212,7 +212,7 @@ var tests = [
   },
   {
     name: 'ParticleFilterRejuvMH',
-    func: 'SMC',
+    method: 'SMC',
     settings: {
       hist: { tol: 0.1 },
       logZ: { check: true, tol: 0.1 },
@@ -241,7 +241,7 @@ var tests = [
   },
   {
     name: 'ParticleFilterRejuvHMC',
-    func: 'SMC',
+    method: 'SMC',
     settings: {
       hist: { tol: 0.1 },
       mean: { tol: 0.2 },
@@ -270,7 +270,7 @@ var tests = [
   },
   {
     name: 'ParticleFilterAsMH',
-    func: 'SMC',
+    method: 'SMC',
     settings: {
       hist: { tol: 0.1 },
       MAP: { tol: 0.15, check: true },
@@ -300,7 +300,7 @@ var tests = [
   },
   {
     name: 'MH',
-    func: 'MCMC',
+    method: 'MCMC',
     settings: {
       hist: { tol: 0.1 },
       MAP: { tol: 0.15, check: true },
@@ -341,7 +341,7 @@ var tests = [
   },
   {
     name: 'HMC',
-    func: 'MCMC',
+    method: 'MCMC',
     settings: {
       hist: { tol: 0.1 },
       mean: { tol: 0.2 },
@@ -461,7 +461,7 @@ var tests = [
   },
   {
     name: 'HMConly',
-    func: 'MCMC',
+    method: 'MCMC',
     settings: {
       hist: { tol: 0.1 },
       mean: { tol: 0.3 },
@@ -475,7 +475,7 @@ var tests = [
   },
   {
     name: 'MHjustSample',
-    func: 'MCMC',
+    method: 'MCMC',
     settings: {
       args: { samples: 100, justSample: true }
     },
@@ -486,11 +486,10 @@ var tests = [
 ];
 
 var wpplRunInference = function(modelName, testDef) {
-  var inferenceFunc = testDef.func || testDef.name;
   var inferenceArgs = getInferenceArgs(testDef, modelName);
   var progText = [
     helpers.loadModel(testDataDir, modelName),
-    inferenceFunc, '(', ['model'].concat(inferenceArgs).join(', '), ');'
+    'Infer(model, ', inferenceArgs, ');'
   ].join('');
   try {
     var retVal;
@@ -523,7 +522,7 @@ var performTest = function(modelName, testDef, test) {
 
 var getInferenceArgs = function(testDef, model) {
   var args = (testDef.models[model] && testDef.models[model].args) || testDef.settings.args;
-  return _.isArray(args) ? args.map(util.serialize) : util.serialize(args);
+  return util.serialize(_.extendOwn({}, args, {method: testDef.method || testDef.name}));
 };
 
 var testFunctions = {


### PR DESCRIPTION
This PR completes the initial implementation of an `Infer` function.

I went with the name `Infer` since that seems to be the name people are using most often when talking about this. (Though personally I've become found of calling this `Marginal` as originally suggested!) I'm not convinced that we should have _multiple_ names for this as originally discussed, that seems likely to cause confusion to me?

Of course, I'm happy to make any changes necessary if people have strong feelings about any of this or if the thinking has changed since #86 was opened.

This PR doesn't include the recent idea of having some heuristic for choosing a good algorithm when `method` isn't specified. To avoid switching the behavior of `Infer(thunk)` on people in the future, I've chosen to not specify a default value for the `method` option of `Infer` in this initial version.

As I mentioned in #86, when deciding whether to apply the caching transform for incremental MH we now look out for `{method: 'IncrementalMH'}` in programs as well as `IncrementalMH`. This is rather crude, but hopefully good enough.