### PR TITLE
Support drift kernels in IncrementalMH.

### DIFF
--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -146,7 +146,8 @@ module.exports = function(env) {
 
   ERPNode.prototype.propose = function() {
     var oldval = this.val;
-    var newval = this.erp.sample();
+    var fwdPropErp = this.erp.driftKernel ? this.erp.driftKernel(oldval) : this.erp;
+    var newval = fwdPropErp.sample();
     tabbedlog(4, this.depth, 'proposing change to ERP.', 'oldval:', oldval, 'newval:', newval);
     // If the value didn't change, then just bail out (we know the
     //    the proposal will be accepted)
@@ -157,10 +158,10 @@ module.exports = function(env) {
     } else {
       updateProperty(this, 'store', _.clone(this.store));
       updateProperty(this, 'val', newval);
-      var oldscore = this.score;
       this.rescore();
-      this.coroutine.rvsPropLP = oldscore;
-      this.coroutine.fwdPropLP = this.score;
+      var rvsPropErp = this.erp.driftKernel ? this.erp.driftKernel(newval) : this.erp;
+      this.coroutine.rvsPropLP = rvsPropErp.score(oldval);
+      this.coroutine.fwdPropLP = fwdPropErp.score(newval);
       tabbedlog(1, this.depth, 'initial rvsPropLP:', this.coroutine.rvsPropLP,
           'initial fwdPropLP:', this.coroutine.fwdPropLP);
       this.needsUpdate = false;

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -75,6 +75,16 @@ var tests = [
       store: { hist: { tol: 0 }, args: { samples: 100 } },
       geometric: true,
       gaussianMean: { mean: { tol: 0.3 }, std: { tol: 0.3 }, args: { samples: 100000 } },
+      gaussianDrift: {
+        mean: { tol: 0.3 },
+        std: { tol: 0.3 },
+        args: { samples: 80000, burn: 20000 }
+      },
+      uniformDrift: {
+        mean: { tol: 0.4 },
+        std: { tol: 0.4 },
+        args: { samples: 200000 }
+      },
       withCaching: true,
       variableSupport: true,
       query: true,


### PR DESCRIPTION
This addresses #421.

IncrementalMH computes large parts of the acceptance probability incrementally as the algorithm proceeds. Since I'm not super familiar with how this goes, I can't be confident this change is correct. Ideally, someone who knows the algorithm well will confirm that this is all we need to do.

However, the existing `gaussianDrift` and `uniformDrift` tests do pass. Also, as an extra check, I've confirmed that this doesn't happen to suffer from the problem described in #147.