### PR TITLE
Run-time checks for sample, score, distribution params

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -170,7 +170,7 @@ function makeDistributionType(options) {
       if (!params.hasOwnProperty(p)) {
         throw 'Parameter \"' + p + '\" missing from ' + this.name + ' distribution.';
       }
-    });
+    }, this);
     this.params = params;
     if (extraConstructorFn !== undefined) {
       extraConstructorFn.call(this);

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -166,11 +166,11 @@ function makeDistributionType(options) {
     if (params === undefined) {
       throw 'Parameters not supplied to ' + this.name + ' distribution.';
     }
-    for (var p of parameterNames) {
+    parameterNames.forEach(function(p) {
       if (!params.hasOwnProperty(p)) {
         throw 'Parameter \"' + p + '\" missing from ' + this.name + ' distribution.';
       }
-    }
+    });
     this.params = params;
     if (extraConstructorFn !== undefined) {
       extraConstructorFn.call(this);

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -146,6 +146,17 @@ function makeDistributionType(options) {
     throw 'makeDistributionType: name is required.';
   }
 
+  // Wrap the score function with args check.
+  if (options.score) {
+    var originalScoreFn = options.score;
+    options.score = function(val) {
+      if (arguments.length !== 1) {
+        throw 'The score method of ' + this.name + ' expected 1 argument but received ' + arguments.length + '.';
+      }
+      return originalScoreFn.call(this, val);
+    };
+  }
+
   // Note that Chrome uses the name of this local variable in the
   // output of `console.log` when it's called on a distribution that
   // uses the default constructor.

--- a/src/header.js
+++ b/src/header.js
@@ -69,6 +69,9 @@ module.exports = function(env) {
   env.defaultCoroutine = env.coroutine;
 
   env.sample = function(s, k, a, dist) {
+    if (!dists.isDist(dist)) {
+      throw 'sample() expected a distribution but received \"' + dist + '\".';
+    }
     return env.coroutine.sample(s, k, a, dist);
   };
 


### PR DESCRIPTION
Following the discussion in #413, this add checks that catch the following:

```
sample(bernoulli({p: .5}))
// => sample() expected a distribution but received "false".

Bernoulli({p: .5}).score([], false);
// => The score method of Bernoulli expected 1 argument but received 2.

Bernoulli()
// => Parameters not supplied to Bernoulli distribution.

Bernoulli({})
// => Parameter "p" missing from Bernoulli distribution.
```

The last of those wasn't suggested in #413, but it seems useful and was asked for anyway in #332.

I ran a few of the tests I ran when we merged the new ERP interface (#393) to see how much time is spent on these checks. It looks like we give back some of the gains we got from the new interface, but things aren't noticeably slower than what we currently have in `dev`.

```
|-----------+-------+------------------+-----------------+----------|
| algo      | model | before #393 (ms) | after #393 (ms) | now (ms) |
|-----------+-------+------------------+-----------------+----------|
| enumerate |     1 |             6365 |            6187 |     6384 |
| mh        |     1 |             8331 |            7605 |     8025 |
| rejection |     1 |             8513 |            7133 |     7798 |
|-----------+-------+------------------+-----------------+----------|
```

Closes #413.