### PR TITLE
Fix error messages that use distribution names

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -151,7 +151,7 @@ function makeDistributionType(options) {
     var originalScoreFn = options.score;
     options.score = function(val) {
       if (arguments.length !== 1) {
-        throw 'The score method of ' + this.name + ' expected 1 argument but received ' + arguments.length + '.';
+        throw 'The score method of ' + this.meta.name + ' expected 1 argument but received ' + arguments.length + '.';
       }
       return originalScoreFn.call(this, val);
     };
@@ -165,11 +165,11 @@ function makeDistributionType(options) {
   // uses the default constructor.
   var dist = function(params) {
     if (params === undefined) {
-      throw 'Parameters not supplied to ' + this.name + ' distribution.';
+      throw 'Parameters not supplied to ' + this.meta.name + ' distribution.';
     }
     parameterNames.forEach(function(p) {
       if (!params.hasOwnProperty(p)) {
-        throw 'Parameter \"' + p + '\" missing from ' + this.name + ' distribution.';
+        throw 'Parameter \"' + p + '\" missing from ' + this.meta.name + ' distribution.';
       }
     }, this);
     this.params = params;

--- a/src/inference/hmckernel.js
+++ b/src/inference/hmckernel.js
@@ -13,7 +13,7 @@ var ad = require('../ad');
 
 module.exports = function(env) {
 
-  var mvDistNames = ['multivariateGaussian', 'dirichlet', 'dirichletDrift'];
+  var mvDistNames = ['MultivariateGaussian', 'Dirichlet', 'DirichletDrift'];
 
   function HMCKernel(cont, oldTrace, options) {
     var options = util.mergeDefaults(options, {
@@ -65,7 +65,7 @@ module.exports = function(env) {
       }
       val = ad.lift(_val);
     } else {
-      if (_.contains(mvDistNames, dist.name)) {
+      if (_.contains(mvDistNames, dist.meta.name)) {
         throw 'Multivariate distributions are not yet supported by HMC.';
       }
       val = prevChoice.val;


### PR DESCRIPTION
These should have been updated as part of 53df102 but I missed them.