### PR TITLE
Implement `toString` on distributions

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -55,8 +55,9 @@ Distribution.prototype = {
     if (_.has(this, 'params')) {
       return [this.meta.name, '(', inspect(this.params), ')'].join('');
     } else {
-      // This isn't an instance of a distribution type, so reinspect
-      // while ignoring this custom inspection method.
+      // This isn't an instance of a distribution type.
+      // e.g. Uniform.prototype.inspect()
+      // Reinspect while ignoring this custom inspection method.
       var opts = options ? _.clone(options) : {};
       opts.customInspect = false;
       return inspect(this, opts);

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -63,6 +63,10 @@ Distribution.prototype = {
     }
   },
 
+  toString: function() {
+    return this.inspect();
+  },
+
   isContinuous: false,
   constructor: Distribution
 


### PR DESCRIPTION
`console.log(dist)` already does something sensible. e.g. displays `Uniform({ a: 0, b: 1 })`.

This change simply overrides `toString` so that `console.log("My dist: " + dist)` (for example) also does something sensible.