### PR TITLE
Make Infer options more consistent

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -35,15 +35,15 @@ Enumeration
    .. describe:: strategy
 
       The traversal strategy used to explore executions. Either
-      ``'likely-first'``, ``'depth-first'`` or ``'breadth-first'``.
+      ``'likelyFirst'``, ``'depthFirst'`` or ``'breadthFirst'``.
 
-      Default: ``'likely-first'`` if ``maxExecutions`` is finite,
-      ``'depth-first'`` otherwise.
+      Default: ``'likelyFirst'`` if ``maxExecutions`` is finite,
+      ``'depthFirst'`` otherwise.
 
    Example usage::
 
      Infer({method: 'enumerate', maxExecutions: 10}, thunk);
-     Infer({method: 'enumerate', strategy: 'breadth-first'}, thunk);
+     Infer({method: 'enumerate', strategy: 'breadthFirst'}, thunk);
 
 Rejection Sampling
 ------------------

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -13,14 +13,14 @@ also known as a `thunk`.
 The inference algorithm to use must be specified using the ``method``
 option. For example::
 
-  Infer({method: 'Enumerate'}, thunk)
+  Infer({method: 'enumerate'}, thunk)
 
 The following algorithms are available:
 
 Enumeration
 -----------
 
-.. js:function:: Infer({method: 'Enumerate'[, ...]}, thunk)
+.. js:function:: Infer({method: 'enumerate'[, ...]}, thunk)
 
    This method performs inference by enumeration.
 
@@ -42,13 +42,13 @@ Enumeration
 
    Example usage::
 
-     Infer({method: 'Enumerate', maxExecutions: 10}, thunk);
-     Infer({method: 'Enumerate', strategy: 'breadth-first'}, thunk);
+     Infer({method: 'enumerate', maxExecutions: 10}, thunk);
+     Infer({method: 'enumerate', strategy: 'breadth-first'}, thunk);
 
 Rejection Sampling
 ------------------
 
-.. js:function:: Infer({method: 'Rejection'[, ...]}, thunk)
+.. js:function:: Infer({method: 'rejection'[, ...]}, thunk)
 
    This method performs inference using rejection sampling.
 
@@ -81,7 +81,7 @@ Rejection Sampling
 
    Example usage::
 
-     Infer({method: 'Rejection', samples: 100}, thunk);
+     Infer({method: 'rejection', samples: 100}, thunk);
 
 MCMC
 ----
@@ -188,7 +188,7 @@ Example usage::
 Incremental MH
 --------------
 
-.. js:function:: Infer({method: 'IncrementalMH'[, ...]}, thunk)
+.. js:function:: Infer({method: 'incrementalMH'[, ...]}, thunk)
 
    This method performs inference using C3. [ritchie15]_
 
@@ -239,7 +239,7 @@ Incremental MH
 
    Example usage::
 
-     Infer({method: 'IncrementalMH', samples: 100, lag: 5, burn: 10}, thunk);
+     Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10}, thunk);
 
    To maximize efficiency when inferring marginals over multiple variables, use the ``query`` table, rather than building up a list of variable values::
 
@@ -257,7 +257,7 @@ Incremental MH
         hmm(100, observed_data);
         return query;
       }
-      Infer({method: 'IncrementalMH', samples: 100, lag: 5, burn: 10}, model);
+      Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10}, model);
 
    ``query`` is a write-only table which can be returned from a program (and thus marginalized). The only operation it supports is adding named values:
 

--- a/examples/binomial.wppl
+++ b/examples/binomial.wppl
@@ -5,4 +5,4 @@ var binomial = function() {
   return a + b + c;
 };
 
-Infer({method: 'Enumerate'}, binomial);
+Infer({method: 'enumerate'}, binomial);

--- a/examples/geometric.wppl
+++ b/examples/geometric.wppl
@@ -2,6 +2,6 @@ var geometric = function(p) {
   return flip(p) ? 1 + geometric(p) : 1;
 };
 
-Infer({method: 'Enumerate', maxExecutions: 10}, function() {
+Infer({method: 'enumerate', maxExecutions: 10}, function() {
   return geometric(0.5);
 });

--- a/examples/hmm.wppl
+++ b/examples/hmm.wppl
@@ -22,7 +22,7 @@ var arrayEq = function(a, b) {
   return (a.length == 0) ? true : (a[0] == b[0] && arrayEq(a.slice(1), b.slice(1)))
 }
 
-Infer({method: 'Enumerate'}, function() {
+Infer({method: 'enumerate'}, function() {
   var r = hmm(3);
   factor(arrayEq(r.observations, trueObservations) ? 0 : -Infinity);
   return r.states;

--- a/examples/hmmIncremental.wppl
+++ b/examples/hmmIncremental.wppl
@@ -22,7 +22,7 @@ var hmm = function(n) {
   return hmmRecur(n, [true], [])
 }
 
-Infer({method: 'Enumerate', maxExecutions: 100}, function() {
+Infer({method: 'enumerate', maxExecutions: 100}, function() {
   var r = hmm(3)
   return r.states
 })

--- a/examples/hmmSampleWithFactor.wppl
+++ b/examples/hmmSampleWithFactor.wppl
@@ -23,7 +23,7 @@ var hmm = function(n) {
   return hmmRecur(n, [true], [])
 }
 
-Infer({method: 'Enumerate', maxExecutions: 500}, function() {
+Infer({method: 'enumerate', maxExecutions: 500}, function() {
   var r = hmm(3)
   return r.states
 })

--- a/examples/pcfg.wppl
+++ b/examples/pcfg.wppl
@@ -35,7 +35,7 @@ var arrayEq = function(a, b) {
   return (a.length == 0) ? true : (a[0] == b[0] && arrayEq(a.slice(1), b.slice(1)))
 }
 
-Infer({method: 'Enumerate', maxExecutions: 300}, function() {
+Infer({method: 'enumerate', maxExecutions: 300}, function() {
   var y = pcfg('start')
   factor(arrayEq(y.slice(0, 2), ['tall', 'John']) ? 0 : -Infinity) //yield starts with "tall John"
   return y[2] ? y[2] : '' //distribution on next word?

--- a/examples/pcfgIncremental.wppl
+++ b/examples/pcfgIncremental.wppl
@@ -40,7 +40,7 @@ var expand = function(symbols, yieldsofar, trueyield) {
   }
 }
 
-Infer({method: 'Enumerate', maxExecutions: 300}, function() {
+Infer({method: 'enumerate', maxExecutions: 300}, function() {
   var y = pcfg('start', [], ['tall', 'John'])
   return y[2] ? y[2] : '' //distribution on next word?
 })

--- a/examples/pragmaticsWithSemanticParsing.wppl
+++ b/examples/pragmaticsWithSemanticParsing.wppl
@@ -148,7 +148,7 @@ var isall = function(world) {
 }
 
 var literalListener = cache(function(utterance) {
-  Infer({method: 'Enumerate', maxExecutions: 100}, function() {
+  Infer({method: 'enumerate', maxExecutions: 100}, function() {
     var m = meaning(utterance)
     var world = worldPrior(2, m)
     factor(m(world) ? 0 : -Infinity)
@@ -157,7 +157,7 @@ var literalListener = cache(function(utterance) {
 })
 
 var speaker = cache(function(world) {
-  Infer({method: 'Enumerate', maxExecutions: 100}, function() {
+  Infer({method: 'enumerate', maxExecutions: 100}, function() {
     var utterance = utterancePrior()
     var L = literalListener(utterance)
     factor(L.score(world))
@@ -166,7 +166,7 @@ var speaker = cache(function(world) {
 })
 
 var listener = function(utterance) {
-  Infer({method: 'Enumerate', maxExecutions: 100}, function() {
+  Infer({method: 'enumerate', maxExecutions: 100}, function() {
     var world = worldPrior(2, function(w) {return 1}) //use vacuous meaning to avoid any guide...
     //    var world = worldPrior(2, meaning(utterance)) //guide by literal meaning
     var S = speaker(world)

--- a/examples/scalarImplicature.wppl
+++ b/examples/scalarImplicature.wppl
@@ -19,7 +19,7 @@ var meaning = function(utt, world) {
 }
 
 var literalListener = cache(function(utterance) {
-  Infer({method: 'Enumerate'}, function() {
+  Infer({method: 'enumerate'}, function() {
     var world = worldPrior()
     var m = meaning(utterance, world)
     factor(m ? 0 : -Infinity)
@@ -28,7 +28,7 @@ var literalListener = cache(function(utterance) {
 })
 
 var speaker = cache(function(world) {
-  Infer({method: 'Enumerate'}, function() {
+  Infer({method: 'enumerate'}, function() {
     var utterance = utterancePrior()
     var L = literalListener(utterance)
     factor(L.score(world))
@@ -37,7 +37,7 @@ var speaker = cache(function(world) {
 })
 
 var listener = function(utterance) {
-  Infer({method: 'Enumerate'}, function() {
+  Infer({method: 'enumerate'}, function() {
     var world = worldPrior()
     var S = speaker(world)
     factor(S.score(utterance))

--- a/examples/semanticParsing.wppl
+++ b/examples/semanticParsing.wppl
@@ -1,5 +1,5 @@
 var literalListener = function(utterance, qud) {
-  Infer({method: 'Enumerate'}, function() {
+  Infer({method: 'enumerate'}, function() {
     var m = meaning(utterance)
     var world = worldPrior(3, m)
     factor(m(world) ? 0 : -Infinity)

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -672,9 +672,23 @@ var ParticleFilterRejuv = function(wpplFn, particles, rejuvSteps) {
 
 var Infer = function(options, wpplFn) {
   assert.ok(_.isObject(options), 'Infer: options argument not given.');
+
+  // Map from camelCase options to PascalCase coroutine names. Also
+  // used to ensure the supplied method name is a valid inference
+  // routine.
+  var methodMap = {
+    SMC: SMC,
+    MCMC: MCMC,
+    PMCMC: PMCMC,
+    asyncPF: AsyncPF,
+    rejection: Rejection,
+    enumerate: Enumerate,
+    incrementalMH: IncrementalMH
+  };
+
   var methodName = options.method;
   assert.ok(methodName, 'Infer: the option \'method\' must be specified.');
-  assert.ok(_.has(_top, methodName), 'Infer: unknown method \'' + methodName + '\'.');
-  var method = _top[methodName];
+  assert.ok(_.has(methodMap, methodName), 'Infer: unknown method \'' + methodName + '\'.');
+  var method = methodMap[methodName];
   return method(wpplFn, _.omit(options, 'method'));
 };

--- a/src/inference/enumerate.ad.js
+++ b/src/inference/enumerate.ad.js
@@ -148,14 +148,14 @@ module.exports = function(env) {
   Enumerate.prototype.incrementalize = env.defaultCoroutine.incrementalize;
 
   var strategies = {
-    'likely-first': {
+    'likelyFirst': {
       makeQ: function() {
         return new PriorityQueue(function(a, b) {
           return a.score - b.score;
         });
       }
     },
-    'depth-first': {
+    'depthFirst': {
       makeQ: function() {
         var q = [];
         q.size = function() {
@@ -166,7 +166,7 @@ module.exports = function(env) {
         return q;
       }
     },
-    'breadth-first': {
+    'breadthFirst': {
       makeQ: function() {
         var q = [];
         q.size = function() {
@@ -180,7 +180,7 @@ module.exports = function(env) {
   };
 
   function defaultStrategy(maxExecutions) {
-    return strategies[_.isFinite(maxExecutions) ? 'likely-first' : 'depth-first'];
+    return strategies[_.isFinite(maxExecutions) ? 'likelyFirst' : 'depthFirst'];
   }
 
   return {

--- a/src/transforms/caching.js
+++ b/src/transforms/caching.js
@@ -77,7 +77,7 @@ function isImhInferMethodOption(node) {
   return node.type === 'Property' &&
       ((node.key.type === 'Identifier' && node.key.name === 'method') ||
       (node.key.type === 'Literal' && node.key.value === 'method')) &&
-      (node.value.type === 'Literal' && node.value.value === 'IncrementalMH');
+      (node.value.type === 'Literal' && node.value.value === 'incrementalMH');
 }
 
 function transformRequired(programAST) {

--- a/tests/test-caching.js
+++ b/tests/test-caching.js
@@ -16,12 +16,12 @@ var hasCachingDirectiveTests = {
 var transformRequiredTests = {
   test1: { code: 'IncrementalMH(model, 0);', expected: true },
   test2: { code: 'Enumerate(model);', expected: false },
-  test3: { code: 'Infer(model, {method: "IncrementalMH"});', expected: true },
-  test4: { code: 'Infer(model, {method: "Enumerate"});', expected: false },
-  test5: { code: '({method: "IncrementalMH"})', expected: true },
-  test6: { code: '({method: "Enumerate"})', expected: false },
-  test7: { code: '({"method": "IncrementalMH"})', expected: true },
-  test8: { code: '({"method": "Enumerate"})', expected: false }
+  test3: { code: 'Infer(model, {method: "incrementalMH"});', expected: true },
+  test4: { code: 'Infer(model, {method: "enumerate"});', expected: false },
+  test5: { code: '({method: "incrementalMH"})', expected: true },
+  test6: { code: '({method: "enumerate"})', expected: false },
+  test7: { code: '({"method": "incrementalMH"})', expected: true },
+  test8: { code: '({"method": "enumerate"})', expected: false }
 };
 
 function generateTests(cases, testFn) {

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -13,7 +13,7 @@ var testDataDir = './tests/test-data/stochastic/';
 var tests = [
   {
     name: 'ForwardSample',
-    method: 'Rejection',
+    method: 'rejection',
     settings: {
       args: { samples: 3000 },
       hist: { tol: 0.05 },
@@ -43,6 +43,7 @@ var tests = [
   },
   {
     name: 'Enumerate',
+    method: 'enumerate',
     settings: {
       args: {},
       MAP: { check: true }
@@ -63,6 +64,7 @@ var tests = [
   },
   {
     name: 'IncrementalMH',
+    method: 'incrementalMH',
     settings: {
       args: { samples: 5000 },
       hist: { tol: 0.1 }
@@ -102,7 +104,7 @@ var tests = [
   },
   {
     name: 'IMHjustSample',
-    method: 'IncrementalMH',
+    method: 'incrementalMH',
     settings: {
       args: { samples: 100, justSample: true }
     },
@@ -128,6 +130,7 @@ var tests = [
   },
   {
     name: 'AsyncPF',
+    method: 'asyncPF',
     settings: {
       args: { particles: 1000, bufferSize: 1000 },
       hist: { tol: 0.1 },
@@ -143,6 +146,7 @@ var tests = [
   },
   {
     name: 'Rejection',
+    method: 'rejection',
     settings: {
       args: { samples: 1000 },
       hist: { tol: 0.1 }
@@ -172,7 +176,7 @@ var tests = [
   },
   {
     name: 'IncrementalRejection',
-    method: 'Rejection',
+    method: 'rejection',
     settings: {
       args: { samples: 1000, incremental: true },
       hist: { tol: 0.1 }


### PR DESCRIPTION
This improves the consistency of `Infer`'s params as discussed in #428. I went with camelCase for the reason @stuhlmueller mentioned.

The existing methods `Enumerate`, `Rejection`, etc. are unchanged.