### PR TITLE
Add score helper to the header.

### DIFF
--- a/examples/ldaCollapsed.wppl
+++ b/examples/ldaCollapsed.wppl
@@ -20,7 +20,7 @@ var makeDirichletDiscrete = function(pseudocounts) {
   };
   var ddObserve = function(val) {
     var pc = globalStore[ddname];  // get current sufficient stats
-    factor(Discrete({ps: normalize(pc)}).score(val));
+    factor(score(Discrete({ps: normalize(pc)}), val));
     // score based on predictive distribution (normalize counts)
     globalStore[ddname] = addCount(pc, val); // update sufficient stats
   };

--- a/examples/linearRegression.wppl
+++ b/examples/linearRegression.wppl
@@ -12,7 +12,7 @@ var model = function() {
 
   map2(
       function(x, y) {
-        factor(Gaussian({mu: f(x), sigma: sigma}).score(y))
+        factor(score(Gaussian({mu: f(x), sigma: sigma}), y))
       },
       xs,
       ys)

--- a/examples/logisticRegression.wppl
+++ b/examples/logisticRegression.wppl
@@ -15,7 +15,7 @@ var model = function() {
 
   map2(
       function(x, label) {
-        factor(Bernoulli({p: sigmoid(x)}).score(label))
+        factor(score(Bernoulli({p: sigmoid(x)}), label))
       },
       xs,
       labels)

--- a/examples/multivariateRegression.wppl
+++ b/examples/multivariateRegression.wppl
@@ -19,7 +19,7 @@ var model = function() {
 
   map2(
       function(x, y) {
-        factor(Gaussian({mu: f(x), sigma: sigma}).score(y))
+        factor(score(Gaussian({mu: f(x), sigma: sigma}), y))
       },
       xs,
       ys)

--- a/examples/pragmaticsWithSemanticParsing.wppl
+++ b/examples/pragmaticsWithSemanticParsing.wppl
@@ -160,7 +160,7 @@ var speaker = cache(function(world) {
   Infer({method: 'Enumerate', maxExecutions: 100}, function() {
     var utterance = utterancePrior()
     var L = literalListener(utterance)
-    factor(L.score(world))
+    factor(score(L, world))
     return utterance
   })
 })
@@ -170,7 +170,7 @@ var listener = function(utterance) {
     var world = worldPrior(2, function(w) {return 1}) //use vacuous meaning to avoid any guide...
     //    var world = worldPrior(2, meaning(utterance)) //guide by literal meaning
     var S = speaker(world)
-    factor(S.score(utterance))
+    factor(score(S, utterance))
     return isall(world)
   })
 }

--- a/examples/scalarImplicature.wppl
+++ b/examples/scalarImplicature.wppl
@@ -31,7 +31,7 @@ var speaker = cache(function(world) {
   Infer({method: 'Enumerate'}, function() {
     var utterance = utterancePrior()
     var L = literalListener(utterance)
-    factor(L.score(world))
+    factor(score(L, world))
     return utterance
   })
 })
@@ -40,7 +40,7 @@ var listener = function(utterance) {
   Infer({method: 'Enumerate'}, function() {
     var world = worldPrior()
     var S = speaker(world)
-    factor(S.score(utterance))
+    factor(score(S, utterance))
     return world
   })
 }

--- a/examples/semiMarkovRandomWalkConstrained.wppl
+++ b/examples/semiMarkovRandomWalkConstrained.wppl
@@ -42,7 +42,7 @@ var transition = function(lastPos, secondLastPos) {
 
 var observeConstrained = function(pos, trueObs) {
   return map2(
-      function(x, obs) { factor(Gaussian({mu: x, sigma: 5}).score(obs)); },
+      function(x, obs) { factor(score(Gaussian({mu: x, sigma: 5}), obs)); },
       pos,
       trueObs
   );

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -226,6 +226,10 @@ var trueF = function() {
 
 // Probability computations & calculations
 
+var score = function(dist, val) {
+  return dist.score(val);
+};
+
 var MAP = function(dist) {
   return dist.MAP();
 };

--- a/tests/test-data/stochastic/models/gaussianDrift.wppl
+++ b/tests/test-data/stochastic/models/gaussianDrift.wppl
@@ -13,7 +13,7 @@ var model = function() {
 
   map2(
       function(x, y) {
-        factor(Gaussian({mu: f(x), sigma: sigma}).score(y));
+        factor(score(Gaussian({mu: f(x), sigma: sigma}), y));
       },
       xs,
       ys);

--- a/tests/test-data/stochastic/models/gaussianMean.wppl
+++ b/tests/test-data/stochastic/models/gaussianMean.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var mu = gaussian(0, 2);
-  factor(Gaussian({mu: mu, sigma: 1}).score(5.5));
-  factor(Gaussian({mu: mu, sigma: 1}).score(6.5));
+  factor(score(Gaussian({mu: mu, sigma: 1}), 5.5));
+  factor(score(Gaussian({mu: mu, sigma: 1}), 6.5));
   return mu;
 };

--- a/tests/test-data/stochastic/models/gaussianMeanVar.wppl
+++ b/tests/test-data/stochastic/models/gaussianMeanVar.wppl
@@ -7,7 +7,7 @@ var model = function() {
   // Posterior marginal over tau is Gamma(a=9, b=3)
   var tau = gamma(a0, 1 / b0);
   var mu = gaussian(mu0, 1 / Math.sqrt(lambda0 * tau));
-  factor(Gaussian({mu: mu, sigma: 1 / Math.sqrt(tau)}).score(1));
-  factor(Gaussian({mu: mu, sigma: 1 / Math.sqrt(tau)}).score(2));
+  factor(score(Gaussian({mu: mu, sigma: 1 / Math.sqrt(tau)}), 1));
+  factor(score(Gaussian({mu: mu, sigma: 1 / Math.sqrt(tau)}), 2));
   return tau;
 };

--- a/tests/test-data/stochastic/models/nestedEnumWithFactor.wppl
+++ b/tests/test-data/stochastic/models/nestedEnumWithFactor.wppl
@@ -5,6 +5,6 @@ var model = function() {
     factor(!z ? 0 : -2);
     return z;
   });
-  factor(marginal.score(true));
+  factor(score(marginal, true));
   return x;
 };


### PR DESCRIPTION
This adds a `score(dist, val)` helper that is equivalent to `dist.score(val)`. See #414 for the rationale behind this.

I don't know whether there's a consensus that this is a good idea.

If we do decide to add this, it makes sense to do it soon so that its use can be promoted in documentation etc.