### PR TITLE
Use `Infer` in more tests/examples.

### DIFF
--- a/examples/hmmSampleWithFactor.wppl
+++ b/examples/hmmSampleWithFactor.wppl
@@ -3,7 +3,9 @@ var transition = function(s) {
 }
 
 var observe = cache(function(s) {
-  Enumerate(function() {return s ? flip(0.9) : flip(0.1)})
+  Infer({method: 'enumerate'}, function() {
+    return s ? flip(0.9) : flip(0.1)
+  })
 })
 
 var trueObs = [false, false, false]

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -2,7 +2,7 @@
 
 QUnit.test('run', function(test) {
   var done = test.async();
-  webppl.run('Enumerate(flip)', function(s, dist) {
+  webppl.run('Infer({method: "enumerate"}, flip)', function(s, dist) {
     test.ok(_.isEqual([false, true], dist.support().sort()));
     done();
   });
@@ -11,7 +11,7 @@ QUnit.test('run', function(test) {
 QUnit.test('run twice', function(test) {
   var done = test.async(2);
   _.times(2, function() {
-    webppl.run('Enumerate(flip)', function(s, dist) {
+    webppl.run('Infer({method: "enumerate"}, flip)', function(s, dist) {
       test.ok(_.isEqual([false, true], dist.support().sort()));
       done();
     });

--- a/tests/test-data/stochastic/models/cache.wppl
+++ b/tests/test-data/stochastic/models/cache.wppl
@@ -1,5 +1,5 @@
 var e = cache(function(x) {
-  return Enumerate(function() {
+  return Infer({method: 'enumerate'}, function() {
     var a = flip(0.5) & flip(0.5);
     factor(a ? 2 : Math.log(0.3));
     return a & x;

--- a/tests/test-data/stochastic/models/importance.wppl
+++ b/tests/test-data/stochastic/models/importance.wppl
@@ -1,5 +1,5 @@
 var makeCoin = function(p) {
-  return Enumerate(function() {return flip(p);});
+  return Infer({method: 'enumerate'}, function() {return flip(p);});
 };
 
 var FairCoin = makeCoin(.5);

--- a/tests/test-data/stochastic/models/importance2.wppl
+++ b/tests/test-data/stochastic/models/importance2.wppl
@@ -1,5 +1,5 @@
 var makeCoin = function(p) {
-  return Enumerate(function() {return flip(p);});
+  return Infer({method: 'enumerate'}, function() {return flip(p);});
 };
 
 var FairCoin = makeCoin(.5);

--- a/tests/test-data/stochastic/models/nestedEnum1.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum1.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     return flip(x);
   });
   var y = sample(marginal);

--- a/tests/test-data/stochastic/models/nestedEnum2.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum2.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     var z = flip(x);
     factor(!z ? 0 : -2);
     return z;

--- a/tests/test-data/stochastic/models/nestedEnum3.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum3.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     return sampleWithFactor(Bernoulli({p: x}), function(value) {
       return !value ? 0 : -2;
     });

--- a/tests/test-data/stochastic/models/nestedEnum4.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum4.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     var z = flip(x);
     factor(z ? 0 : -Infinity);
     assert.ok(z);

--- a/tests/test-data/stochastic/models/nestedEnum5.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum5.wppl
@@ -1,13 +1,13 @@
 var model = function() {
   var x = uniform(0, 1);
 
-  var firstMarginal = Enumerate(function() {
+  var firstMarginal = Infer({method: 'enumerate'}, function() {
     var y = flip(x);
     factor(!y ? 0 : -3);
     return y;
   });
 
-  var secondMarginal = Enumerate(function() {
+  var secondMarginal = Infer({method: 'enumerate'}, function() {
     var z = sample(firstMarginal);
     factor(z ? 1 : -1);
     return z;

--- a/tests/test-data/stochastic/models/nestedEnum6.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum6.wppl
@@ -1,9 +1,9 @@
 var model = function() {
   var x = uniform(0, 1);
 
-  var outerMarginal = Enumerate(function() {
+  var outerMarginal = Infer({method: 'enumerate'}, function() {
 
-    var innerMarginal = Enumerate(function() {
+    var innerMarginal = Infer({method: 'enumerate'}, function() {
       var y = flip(x);
       factor(y ? 1 : -1);
       return y;

--- a/tests/test-data/stochastic/models/nestedEnum7.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum7.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     var z = flip();
     factor(z ? -2 * x : 0);
     return z;

--- a/tests/test-data/stochastic/models/nestedEnum8.wppl
+++ b/tests/test-data/stochastic/models/nestedEnum8.wppl
@@ -4,7 +4,7 @@ var logistic = function(z) {
 
 var model = function() {
   var x = logistic(gaussian(3, 2));
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     var z = flip(x);
     factor(!z ? 0 : -2);
     return z;

--- a/tests/test-data/stochastic/models/nestedEnumDiscrete.wppl
+++ b/tests/test-data/stochastic/models/nestedEnumDiscrete.wppl
@@ -1,4 +1,4 @@
-var marginal = Enumerate(function() {
+var marginal = Infer({method: 'enumerate'}, function() {
   var x = flip();
   var y = flip();
   factor((x | y) ? 0 : -Infinity);

--- a/tests/test-data/stochastic/models/nestedEnumWithFactor.wppl
+++ b/tests/test-data/stochastic/models/nestedEnumWithFactor.wppl
@@ -1,6 +1,6 @@
 var model = function() {
   var x = uniform(0, 1);
-  var marginal = Enumerate(function() {
+  var marginal = Infer({method: 'enumerate'}, function() {
     var z = flip(x);
     factor(!z ? 0 : -2);
     return z;


### PR DESCRIPTION
Switch from using `Enumerate` to using `Infer` in a few spots I missed in earlier changes.