### PR TITLE
Tweak parameters to address CI failures of nestedEnumWithFactor

### DIFF
--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -472,7 +472,15 @@ var tests = [
           kernel: { HMC: { steps: 20, stepSize: 0.2 } }
         }
       },
-      nestedEnumWithFactor: { mean: { tol: 0.075 }, std: { tol: 0.075 } }
+      nestedEnumWithFactor: {
+        mean: { tol: 0.075 },
+        std: { tol: 0.075 },
+        args: {
+          samples: 1500,
+          burn: 1500,
+          kernel: { HMC: { steps: 50, stepSize: 0.01 }}
+        }
+      }
     }
   },
   {


### PR DESCRIPTION
`nestedEnumWithFactor` fails when `x` is initialized to a value close to zero. (10^-3 in this case.)

I think the problem is that the posterior probability in this region is close to zero, so the HMC gradients are large, which leads to lots of rejections without a sufficiently small step size.

I've reduced the step size (to reduce rejections) and bumped up the number of steps (so we still explore). I've also added some burn in so that an initial period spent recovering from a bad init doesn't hurt too much.

I ran the test 100 times initializing `x` to 10^-4 and only had one failure, which is a significant reduction in the failure rate over the current settings with this initialization I think.

Closes #456.