### PR TITLE
Fix binomial sampler support bug

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -581,7 +581,7 @@ function binomialSample(p, n) {
   var N = 10;
   var a, b;
   while (n > N) {
-    a = 1 + n / 2;
+    a = Math.floor(1 + n / 2);
     b = 1 + n - a;
     var x = betaSample(a, b);
     if (x >= p) {

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -921,10 +921,10 @@ var Categorical = makeDistributionType({
 var Delta = makeDistributionType({
   name: 'Delta',
   desc: 'Discrete distribution that assigns probability one to the single ' +
-    'element in its support. This is only useful in special circumstances as sampling ' +
-    'from ``Delta({v: val})`` can be replaced with ``val`` itself. Furthermore, a ``Delta`` ' +
-    'distribution parameterized by a random choice should not be used with MCMC based inference, ' +
-    'as doing so produces incorrect results.',
+      'element in its support. This is only useful in special circumstances as sampling ' +
+      'from ``Delta({v: val})`` can be replaced with ``val`` itself. Furthermore, a ``Delta`` ' +
+      'distribution parameterized by a random choice should not be used with MCMC based inference, ' +
+      'as doing so produces incorrect results.',
   params: [{name: 'v', desc: 'support element'}],
   mixins: [finiteSupport],
   constructor: function() {
@@ -970,6 +970,7 @@ module.exports = {
   Categorical: Categorical,
   Delta: Delta,
   // rng
+  binomialSample: binomialSample,
   discreteSample: discreteSample,
   gaussianSample: gaussianSample,
   gammaSample: gammaSample,

--- a/src/statistics.js
+++ b/src/statistics.js
@@ -108,6 +108,13 @@ function kde(samps, kernel) {
   return results;
 }
 
+function mode(samps) {
+  // TODO: accommodate multimodality
+  // tally values and sort
+  var tallied = _.sortBy(_.pairs(_.countBy(samps)), '1');
+  return _.last(tallied)[0];
+}
+
 // estimate the mode of a continuous distribution from some
 // samples by computing kde and returning the bin with
 // max density
@@ -138,5 +145,6 @@ module.exports = {
   skew: skew,
   kurtosis: kurtosis,
   kde: kde,
-  kdeMode: kdeMode
+  kdeMode: kdeMode,
+  mode: mode
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -43,7 +43,7 @@ var testWithinTolerance = function(test, actual, expected, tolerance, name, verb
     actual: actual,
     tolerance: tolerance
   });
-  var isOk = absDiff < tolerance;
+  var isOk = absDiff <= tolerance;
   if (!isOk && verbose) {
     console.log(msg)
   }

--- a/tests/test-data/sampler/binomial.js
+++ b/tests/test-data/sampler/binomial.js
@@ -1,0 +1,78 @@
+var dists = require('../../../src/dists');
+var util = require('../../../src/util');
+var statistics = require('../../../src/statistics');
+
+var ln = Math.log,
+    pow = Math.pow,
+    sqrt = Math.sqrt,
+    abs = Math.abs;
+
+
+module.exports = {
+  name: 'binomial',
+  sampler: dists.binomialSample,
+  inSupport: function(params, x) {
+    var n = params[1];
+    return typeof x === 'number' && x % 1 === 0 & x >= 0 && x <= n;
+  },
+  settings: [
+    // params are passed to the sampler
+    // n is the number of samples we'll take
+    // reltol declares which stats we'll run for a single parameter value
+    // and the acceptable relative tolerance for each
+
+    {params: [0.5, 22], n: 1e06, skip: ['mode', 'skew', 'kurtosis']},
+
+    // just check support for large n
+    // {params: [0.5, 100000], n: 1e06, skip: ['mean','variance', 'mode', 'skew', 'kurtosis']}
+  ],
+  moment: function(params, N) {
+    // returns the Nth moment
+    var p = params[0];
+    var n = params[1];
+
+    if (N == 1) {
+      return n * p;
+    } else if (N == 2) {
+      return n * p * (1 - p)
+    } else if (N == 3) {
+      // HT mathematica
+      return n * p * ((n - 2) * (n - 1) * p * p + 3 * (n - 1) * p + 1);
+    } else if (N == 4) {
+      // HT mathematica
+      return n * p * ((n - 3) * (n - 2) * (n - 1) * p * p * p + 6 * (n - 2) * (n - 1) * p * p + 7 * (n - 1) * p + 1)
+    }
+  },
+  // mostly HT https://en.wikipedia.org/wiki/Gamma_distribution
+  populationStatisticFunctions: {
+    mean: function(params) {
+      var p = params[0];
+      var n = params[1];
+      return n * p;
+    },
+    mode: function(params) {
+      var p = params[0];
+      var n = params[1];
+      // todo: when (n+1)p is an integer and p != 0 or 1,
+      // then there are two modes: (n+1)p and (n+1)p - 1
+      return Math.floor((n + 1) * p)
+    },
+    variance: function(params) {
+      var p = params[0];
+      var n = params[1];
+      return n * p * (1 - p);
+    },
+    skew: function(params) {
+      var p = params[0];
+      var n = params[1];
+      return (1 - 2 * p) / sqrt(n * p * (1 - p));
+
+    },
+    kurtosis: function(params) {
+      var p = params[0];
+      var n = params[1];
+      return (1 - 6 * p * (1 - p)) / (n * p * (1 - p));
+
+    }
+  }
+}

--- a/tests/test-data/sampler/binomial.js
+++ b/tests/test-data/sampler/binomial.js
@@ -72,7 +72,7 @@ module.exports = {
     kurtosis: function(params) {
       var p = params[0];
       var n = params[1];
-      return (1 - 6 * p * (1 - p)) / (n * p * (1 - p));
+      return 3 + (1 - 6 * p * (1 - p)) / (n * p * (1 - p));
 
     }
   }

--- a/tests/test-data/sampler/binomial.js
+++ b/tests/test-data/sampler/binomial.js
@@ -22,10 +22,25 @@ module.exports = {
     // reltol declares which stats we'll run for a single parameter value
     // and the acceptable relative tolerance for each
 
-    {params: [0.5, 22], n: 1e06, skip: ['mode', 'skew', 'kurtosis']},
+    // edge cases
+    {params: [0.0, 1], n: 1e02, skip: ['skew', 'kurtosis'], reltol: {mode: 0.05}},
+    {params: [1.0, 1], n: 1e02, skip: ['mode', 'skew', 'kurtosis'], reltol: {mode: 0.05}},
+    {params: [0.0, 201], n: 1e02, skip: ['skew', 'kurtosis'], reltol: {mode: 0.05}},
+    {params: [1.0, 201], n: 1e02, skip: ['mode', 'skew', 'kurtosis'], reltol: {mode: 0.05}},
 
-    // just check support for large n
-    {params: [0.5, 100000], n: 1e06, skip: ['mean', 'variance', 'mode', 'skew', 'kurtosis']}
+
+    {params: [0.1, 1], n: 1e04, skip: ['skew', 'kurtosis'], reltol: {mode: 0.05}},
+    {params: [0.9, 1], n: 1e04, skip: ['skew', 'kurtosis'], reltol: {mode: 0.05}},
+
+    {params: [0.5, 22], n: 1e05, reltol: {mode: 0.05}},
+
+    {params: [0.37, 51], n: 1e05, reltol: {mode: 0.05}},
+    {params: [0.37, 101], n: 1e05, reltol: {mode: 0.05}},
+    {params: [0.37, 201], n: 1e05, reltol: {mode: 0.05}},
+    {params: [0.37, 100000], n: 1e05, reltol: {mode: 0.05}},
+
+    {params: [0.001, 201], n: 1e05, reltol: {mode: 0.05}},
+    {params: [0.999, 201], n: 1e05, reltol: {mode: 0.05}}
   ],
   moment: function(params, N) {
     // returns the Nth moment

--- a/tests/test-data/sampler/binomial.js
+++ b/tests/test-data/sampler/binomial.js
@@ -24,7 +24,7 @@ module.exports = {
     {params: [0.5, 22], n: 1e06, skip: ['mode', 'skew', 'kurtosis']},
 
     // just check support for large n
-    // {params: [0.5, 100000], n: 1e06, skip: ['mean','variance', 'mode', 'skew', 'kurtosis']}
+    {params: [0.5, 100000], n: 1e06, skip: ['mean', 'variance', 'mode', 'skew', 'kurtosis']}
   ],
   moment: function(params, N) {
     // returns the Nth moment

--- a/tests/test-data/sampler/binomial.js
+++ b/tests/test-data/sampler/binomial.js
@@ -11,6 +11,7 @@ var ln = Math.log,
 module.exports = {
   name: 'binomial',
   sampler: dists.binomialSample,
+  type: 'integer',
   inSupport: function(params, x) {
     var n = params[1];
     return typeof x === 'number' && x % 1 === 0 & x >= 0 && x <= n;

--- a/tests/test-samplers.js
+++ b/tests/test-samplers.js
@@ -43,7 +43,8 @@ var sampleStatisticFunctions = {
 }
 
 var distMetadataList = [
-  require('./test-data/sampler/gamma')
+  require('./test-data/sampler/gamma'),
+  require('./test-data/sampler/binomial')
 ];
 
 var generateSettingTest = function(seed, distMetadata, settings) {
@@ -72,11 +73,16 @@ var generateSettingTest = function(seed, distMetadata, settings) {
     // use for loop because some nodes don't define map()
     // for Float64Array
     var allInSupport = true;
+    var outsideSupport = [];
     for (var i = 0, ii = samples.length; i < ii; i++) {
-      allInSupport = allInSupport && distMetadata.inSupport(params, samples[i]);
+      var inSupport = distMetadata.inSupport(params, samples[i]);
+      allInSupport = allInSupport && inSupport;
+      if (!inSupport) {
+        outsideSupport.push(samples[i])
+      }
     }
 
-    test.ok(allInSupport);
+    test.ok(allInSupport, 'support test failed ' + outsideSupport.slice(0, 10).join(', '));
 
     // then check each populationStatisticFunction
     _.each(populationStatisticFunctions, function(statFn, statName) {

--- a/tests/test-samplers.js
+++ b/tests/test-samplers.js
@@ -128,7 +128,12 @@ var generateSettingTest = function(seed, distMetadata, settings) {
       autoTolerance = autoToleranceMultiple[statName] * sqrt(samplingDistVariance);
 
 
-      var sampleStatisticFunction = sampleStatisticFunctions[statName];
+      var sampleStatisticFunction;
+      if (statName == 'mode') {
+        sampleStatisticFunction = (distMetadata.type == 'integer') ? statistics.mode : statistics.kdeMode
+      } else {
+        sampleStatisticFunction = sampleStatisticFunctions[statName];
+      }
       var actualResult = sampleStatisticFunction(samples);
 
       var tolerance;


### PR DESCRIPTION
This would close #457

Re 457: our sampler would return non-integer values because our method, adapted from Ahrens & Dieter 1974, samples from a `beta(a,b)` distribution where `a,b` must be integers but we passed in non-integers for odd `n` > 20.

This PR adds sampler tests and fixes the bug.