### PR TITLE
Optionally return src map from compile in browser.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -42,8 +42,9 @@ function compile(code, options) {
   if (options === undefined) {
     options = {};
   }
-  var optionsExtended = _.extend({bundles: load()}, options);
-  return webppl.compile(code, optionsExtended).code;
+  var optionsExtended = _.extend({bundles: load()}, _.omit(options, 'sourceMap'));
+  var codeAndMap = webppl.compile(code, optionsExtended);
+  return options.sourceMap ? codeAndMap : codeAndMap.code;
 }
 
 function webpplCPS(code) {

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -22,6 +22,12 @@ QUnit.test('compile', function(test) {
   test.ok(_.isString(webppl.compile('1 + 1')));
 });
 
+QUnit.test('compile with source map', function(test) {
+  var codeAndMap = webppl.compile('1 + 1', {sourceMap: true});
+  test.ok(_.isString(codeAndMap.code));
+  test.ok(_.isObject(codeAndMap.map));
+});
+
 QUnit.test('cps', function(test) {
   var code = webppl.cps('100');
   eval(code)(function(val) {


### PR DESCRIPTION
This adds an option to `webppl.compile` (in the browser) to return the source map along with the code. The editor needs this to generate readable errors.