### PR TITLE
Source map only those errors that occur in eval.

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -109,13 +109,14 @@ function getErrorPosition(error) {
   firstStackFrame.columnNumber--;
   firstStackFrame.sourceMapped = false;
 
-  if (error.sourceMaps === undefined || firstStackFrame.native) {
+  if (error.sourceMaps === undefined ||
+      !firstStackFrame.functionName.startsWith('eval')) {
     return firstStackFrame;
   }
 
-  // Check whether the error occurred in compiled code. We only need
-  // to check the first source map as this is the one added when the
-  // error was first caught.
+  // Error occurred in evaled/compiled code.
+  // We only need to check the first source map as this is the one
+  // added when the error was first caught.
 
   var mapConsumer = new SourceMap.SourceMapConsumer(error.sourceMaps[0]);
   var originalPosition = mapConsumer.originalPositionFor({
@@ -123,16 +124,13 @@ function getErrorPosition(error) {
     column: firstStackFrame.columnNumber
   });
 
-  if (originalPosition.source === null) {
-    return firstStackFrame;
-  } else {
-    return {
-      fileName: originalPosition.source,
-      lineNumber: originalPosition.line,
-      columnNumber: originalPosition.column,
-      sourceMapped: true
-    };
-  }
+  return {
+    fileName: originalPosition.source,
+    lineNumber: originalPosition.line,
+    columnNumber: originalPosition.column,
+    sourceMapped: true
+  };
+
 }
 
 module.exports = {


### PR DESCRIPTION
Previously all errors (including those originating in plain JS) were
looked up in the source map. It was often the case that this happened to
work because the map doesn't contain entries for most line, column
number pairs. But when there was a match, it led to incorrect reported
of the origin of the error.

This commit removes the explicit check for errors occurring in native
code as those are a subset of the cases now caught by the 'eval' check.

I've manually tested this against all the programs we came up with while reviewing the original PR and they all still work.
