### PR TITLE
Have indexOf follow the behavior of the JS version

### DIFF
--- a/src/header.wppl
+++ b/src/header.wppl
@@ -542,9 +542,7 @@ var takeWhile = function(p, ar) {
 };
 
 var indexOf = function(x, xs) {
-  // prototype method doesn't return falsy value if not found
-  var i = xs.indexOf(x);
-  return i < 0 ? undefined : i
+  return xs.indexOf(x);
 };
 
 var minWith = function(f, ar) {


### PR DESCRIPTION
Returning a falsey value when the item is not found isn't super useful
since zero is falsey too. Rather than giving the impression that this
might be equivalent to something like _.contains when used as a
predicate, I think it's clearer to have this follow the behavior of the
JS version.

I noticed this while working on #323. None of the 3 uses of `indexOf` I found there would be affected by this change.