### PR TITLE
Remove bold from inline code within js:function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 npm-debug.log
 bundle/
 docs/_build
-docs/_static
 docs/_templates
 src/dists.js
 src/inference/enumerate.js

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,2 @@
+/* don't use bold on inline code within js:function blocks */
+.rst-content dl:not(.docutils) code { font-weight: normal; }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,11 @@ todo_include_todos = False
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# https://obda.net/blog/custom-css-and-js-for-sphinx-generated-documentation/
+html_context = {
+    'css_files': ['_static/custom.css']
+}
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.


### PR DESCRIPTION
We document functions using the js:function markup from Sphinx's
Javascript domain. Inline code within these blocks currently uses font
weight bold. This looks bad, and it differs from the formatting used
outside of these blocks. This fixes that.

Before:
![before](https://cloud.githubusercontent.com/assets/9109012/16309902/4afdc776-3962-11e6-918f-f8ffb25f6016.png)

After:
![after](https://cloud.githubusercontent.com/assets/9109012/16309904/4ecc6574-3962-11e6-9911-7a8120dbd79f.png)