### PR TITLE
Increase phantomjs timeout from default of 5 seconds.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,8 +131,9 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('test-phantomjs', 'Run browser tests in phantomjs.', function() {
+    var timeout = 10; // seconds
     try {
-      var cmd = 'phantomjs node_modules/qunit-phantomjs-runner/runner-list.js tests/browser/index.html';
+      var cmd = 'phantomjs node_modules/qunit-phantomjs-runner/runner-list.js tests/browser/index.html ' + timeout;
       var output = child_process.execSync(cmd);
       grunt.log.writeln(output);
     } catch (e) {


### PR DESCRIPTION
I added an extra test as part of the readable error messages work, maybe that was enough extra work to occasionally trigger this.

This test seems to work fine for me locally, typically taking ~2.5 seconds to complete. The default timeout is 5 seconds. I'm hoping that increasing the timeout to 10 seconds will fix this.

Closes #520.