### PR TITLE
Remove unused math functions

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -869,18 +869,6 @@ function betaSample(a, b) {
 }
 
 
-function binomialG(x) {
-  'use ad';
-  if (x === 0) {
-    return 1;
-  }
-  if (x === 1) {
-    return 0;
-  }
-  var d = 1 - x;
-  return (1 - (x * x) + (2 * x * Math.log(x))) / (d * d);
-}
-
 // see lemma 6.1 from Ahrens & Dieter's
 // Computer Methods for Sampling from Gamma, Beta, Poisson and Binomial Distributions
 function binomialSample(p, n) {

--- a/src/math/special.js
+++ b/src/math/special.js
@@ -20,6 +20,7 @@ function logGamma(xx) {
   return -tmp + Math.log(2.5066282746310005 * ser);
 }
 
+// https://en.wikipedia.org/wiki/Digamma_function#Computation_and_approximation
 function digamma(x) {
   if (x < 6) {
     return digamma(x + 1) - 1 / x;

--- a/src/math/statistics.js
+++ b/src/math/statistics.js
@@ -16,38 +16,6 @@ function expectation(a, func) {
   }, 0) / a.length;
 }
 
-// HT https://en.wikipedia.org/wiki/Digamma_function#Computation_and_approximation
-var digamma = function(x) {
-  if (x < 6)
-    return digamma(x + 1) - 1 / x;
-
-  return ln(x) -
-      1 / (2 * x) -
-      1 / (12 * pow(x, 2)) +
-      1 / (120 * pow(x, 4)) -
-      1 / (252 * pow(x, 6)) +
-      1 / (240 * pow(x, 8)) -
-      5 / (660 * pow(x, 10)) +
-      691 / (32760 * pow(x, 12)) -
-      1 / (12 * pow(x, 14));
-}
-
-// HT http://ms.mcmaster.ca/peter/s743/trigamma.html
-// (cites formulas from abramowitz & stegun, which you can get at:
-// http://people.math.sfu.ca/~cbm/aands/)
-var trigamma = function(x) {
-  if (x < 30) {
-    return trigamma(x + 1) + 1 / (x * x);
-  }
-
-  return 1 / x +
-      1 / (2 * pow(x, 2)) +
-      1 / (6 * pow(x, 3)) -
-      1 / (30 * pow(x, 5)) +
-      1 / (42 * pow(x, 7)) -
-      1 / (30 * pow(x, 9))
-}
-
 function mean(a) {
   return expectation(a)
 }
@@ -136,8 +104,6 @@ function kdeMode(samps) {
 }
 
 module.exports = {
-  digamma: digamma,
-  trigamma: trigamma,
   mean: mean,
   variance: variance,
   sd: sd,


### PR DESCRIPTION
I planned to move `trigamma` into `special.js`, but when I looked it's not currently in use. @longouyang: any reason to keep this function around?

We don't appear to use `binomialG` anymore either.

We retain a copy of `digamma` in `special.js`.