### PR TITLE
Make webppl installable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "through2": "^2.0.0"
   },
   "scripts": {
-    "test": "nodeunit tests/test-*.js",
+    "test": "nodeunit tests",
     "postinstall": "node scripts/adify"
   },
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "test": "nodeunit tests/test-*.js",
-    "postinstall": "./scripts/adify"
+    "postinstall": "node scripts/adify"
   },
   "bugs": {
     "url": "https://github.com/probmods/webppl/issues"

--- a/scripts/adify
+++ b/scripts/adify
@@ -28,7 +28,7 @@ function adRequirePath(srcFilename) {
   var dir = path.dirname(srcFilename);
   var adFileName = path.join(__dirname, '..', 'src', 'ad.js');
   var adPath = path.normalize(path.dirname(path.relative(dir, adFileName)));
-  return adPath + path.sep + 'ad.js';
+  return adPath + '/' + 'ad.js';
 }
 
 // Don't match text editor temporary files. e.g. src/.#dists.ad.js

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,1 @@
 NOTE: `helpers/helpers.js` cannot be moved to the top-level tests directory. For Windows compatibility, we alias `npm test` to `nodeunit tests`, which runs all the .js files in the top-level directory; helpers.js is not a valid nodeunit file, so this would cause tests to fail.
-
-TODO: document testing infrastructure more

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+NOTE: `helpers/helpers.js` cannot be moved to the top-level tests directory. For Windows compatibility, we alias `npm test` to `nodeunit tests`, which runs all the .js files in the top-level directory; helpers.js is not a valid nodeunit file, so this would cause tests to fail.
+
+TODO: document testing infrastructure more

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -1,3 +1,8 @@
+// NOTE: this file cannot live in the top-level tests directory. For compatibility
+// with Windows, we alias `npm test` to `nodeunit tests`, which runs all the .js
+// files in the top-level directory; helpers.js is not a valid nodeunit file, so
+// this would cause tests to fail
+
 'use strict';
 
 var _ = require('underscore');

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -3,8 +3,8 @@
 var _ = require('underscore');
 var fs = require('fs');
 var assert = require('assert');
-var webppl = require('../src/main');
-var util = require('../src/util');
+var webppl = require('../../src/main');
+var util = require('../../src/util');
 var serialize = util.serialize;
 
 _.templateSettings = {

--- a/tests/test-deterministic.js
+++ b/tests/test-deterministic.js
@@ -3,7 +3,7 @@
 // Tests for deterministic code written in webppl (e.g., preamble functions)
 
 var webppl = require('../src/main');
-var helpers = require('./helpers');
+var helpers = require('./helpers/helpers');
 
 var testDataDir = './tests/test-data/deterministic/';
 

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var assert = require('assert');
 var util = require('../src/util');
 var webppl = require('../src/main');
-var helpers = require('./helpers');
+var helpers = require('./helpers/helpers');
 
 var testDataDir = './tests/test-data/stochastic/';
 

--- a/tests/test-samplers.js
+++ b/tests/test-samplers.js
@@ -10,7 +10,7 @@ var seedrandom = require('seedrandom');
 var assert = require('assert');
 var util = require('../src/util');
 var webppl = require('../src/main');
-var helpers = require('./helpers');
+var helpers = require('./helpers/helpers');
 var statistics = require('../src/math/statistics');
 
 var repeat = function(n, f) {

--- a/tests/test-scorers.js
+++ b/tests/test-scorers.js
@@ -1,7 +1,7 @@
 var webppl = require('../src/main');
 var util = require('../src/util');
 var dists = require('../src/dists');
-var helpers = require('./helpers');
+var helpers = require('./helpers/helpers');
 
 // notes for more extensive tests
 // binomial space: N * P * X


### PR DESCRIPTION
I tested on Windows 7 using a [free VM that Microsoft provides](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/). Installing this:

```sh
npm install -g longouyang/webppl#d824cce
```
worked.