### PR TITLE
Reset env before running code in the browser.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -33,7 +33,7 @@ function run(code, k, options) {
     options = {};
   }
   var optionsExtended = _.extend({bundles: load()}, options);
-
+  webppl.resetEnv();
   return webppl.run(code, k, optionsExtended);
 }
 
@@ -63,5 +63,6 @@ global.webppl = {
   compile: compile,
   cps: webpplCPS,
   naming: webpplNaming,
-  version: version
+  version: version,
+  resetEnv: webppl.resetEnv
 };

--- a/src/header.js
+++ b/src/header.js
@@ -71,6 +71,10 @@ module.exports = function(env) {
 
   env.defaultCoroutine = env.coroutine;
 
+  env.reset = function() {
+    env.coroutine = env.defaultCoroutine;
+  };
+
   env.sample = function(s, k, a, dist, options) {
     if (!dists.isDist(dist)) {
       throw new Error('sample() expected a distribution but received \"' + JSON.stringify(dist) + '\".');

--- a/src/main.js
+++ b/src/main.js
@@ -242,5 +242,6 @@ module.exports = {
   requireHeaderWrapper: requireHeaderWrapper,
   parsePackageCode: parsePackageCode,
   run: run,
-  compile: compile
+  compile: compile,
+  resetEnv: env.reset
 };


### PR DESCRIPTION
Without this, an exception occurring in one call to `run` leaves `env` in an unpredictable state for subsequent calls.

Ideally this would be handled entirely internally, but at present the editor calls `compile` and `eval` when running code, so for now it will also have to call `webppl.resetEnv`. The work I've been doing on #314 should allow us to remedy this. It will also make it much easier for me to write a test for this.

Closes #550.