### PR TITLE
Capitalization: WebPPL, JavaScript, headings

### DIFF
--- a/docs/development/workflow.rst
+++ b/docs/development/workflow.rst
@@ -74,7 +74,7 @@ many of them automatically using::
 Browser version
 ---------------
 
-To generate a version of webppl for in-browser use, run::
+To generate a version of WebPPL for in-browser use, run::
 
     npm install -g browserify uglifyjs
     grunt bundle
@@ -95,7 +95,7 @@ using the ``BROWSER`` environment variable. For example::
 
     BROWSER="Google Chrome" grunt test-browser
 
-Incremental Compilation
+Incremental compilation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Repeatedly making changes to the code and then testing the changes in

--- a/docs/globalstore.rst
+++ b/docs/globalstore.rst
@@ -4,7 +4,7 @@ The Global Store
 Background
 ~~~~~~~~~~
 
-The subset of Javascript supported by WebPPL does not include general
+The subset of JavaScript supported by WebPPL does not include general
 assignment expressions. This means it is not possible to change the
 value bound to a variable, or to modify the contents of a compound
 data structure::
@@ -28,7 +28,7 @@ However, assignment can occasionally be useful, and for this reason
 WebPPL provides a limited form of it through something called the
 global store.
 
-Introducing the Global Store
+Introducing the global store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The global store is a built-in data structure with special status in
@@ -43,7 +43,7 @@ be modified. Here's a simple example::
   display(globalStore.x) // prints 2
 
 When reading and writing to the global store, it behaves like a plain
-Javascript object. As in Javascript, the value of each property is
+JavaScript object. As in JavaScript, the value of each property is
 initially ``undefined``.
 
 Note that while the store can be modified by assigning and reassigning
@@ -56,7 +56,7 @@ structures referenced by those properties::
   globalStore.foo = {x: 0}
   globalStore.foo.x = 1 // attempting to mutate foo fails
 
-Marginal Inference and the Global Store
+Marginal inference and the global store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Crucially, all marginal inference algorithms are aware of the global

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -44,7 +44,7 @@ Enumeration
      Infer({method: 'enumerate', maxExecutions: 10}, model);
      Infer({method: 'enumerate', strategy: 'breadthFirst'}, model);
 
-Rejection Sampling
+Rejection sampling
 ------------------
 
 .. js:function:: Infer({method: 'rejection'[, ...]}, model)
@@ -262,7 +262,7 @@ Incremental MH
 
       .. js:function:: query.add(name, value)
 
-         :param any name: Name of value to be added to query. Will be converted to string, as Javascript object keys are.
+         :param any name: Name of value to be added to query. Will be converted to string, as JavaScript object keys are.
          :param any value: Value to be added to query.
          :returns: undefined
 

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -1,4 +1,4 @@
-The WebPPL language
+The WebPPL Language
 =========
 
 The WebPPL language begins with a subset of JavaScript, and adds to it primitive distributions and primitives to sample, Infer, etc.

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -1,4 +1,4 @@
-The WebPPL Language
+The WebPPL language
 =========
 
 The WebPPL language begins with a subset of JavaScript, and adds to it primitive distributions and primitives to sample, Infer, etc.

--- a/docs/language.rst
+++ b/docs/language.rst
@@ -1,9 +1,9 @@
 The WebPPL Language
 =========
 
-The WebPPL language begins with a subset of Javascript, and adds to it primitive distributions and primitives to sample, Infer, etc.
+The WebPPL language begins with a subset of JavaScript, and adds to it primitive distributions and primitives to sample, Infer, etc.
 
-Following the notation from the [Mozilla Parser API](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API), the language consists of the subset of Javascript that can be built from the following syntax elements, each shown with an `example`:
+Following the notation from the [Mozilla Parser API](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API), the language consists of the subset of JavaScript that can be built from the following syntax elements, each shown with an `example`:
 
 - *Program* - a complete program, consisting of a sequence of statements
 - *BlockStatement* - a sequence of statements surrounded by braces, `{ var x=1; var y=2; }`
@@ -26,7 +26,7 @@ Following the notation from the [Mozilla Parser API](https://developer.mozilla.o
 - `global` *AssignmentExpression* - `globalStore.a = 1`
 
 Note that assignment (*AssignmentExpression*) is currently only supported for the `globalStore object`, and no looping constructs are currently supported (e.g., `for`, `while`, `do`). This is because a purely functional language is much easier to transform into Continuation-Passing Style (CPS), which the WebPPL implementation uses to implement inference algorithms such as Enumeration and Particle Filtering.
-While these restrictions mean that common Javascript programming patterns aren't possible, this subset is still universal, because we allow recursive and higher-order functions. It encourages a functional style, similar to Haskell or LISP, that is pretty easy to use (once you get used to thinking functionally!).
+While these restrictions mean that common JavaScript programming patterns aren't possible, this subset is still universal, because we allow recursive and higher-order functions. It encourages a functional style, similar to Haskell or LISP, that is pretty easy to use (once you get used to thinking functionally!).
 
 Distributions, sampling, factor, inference
 ---------
@@ -41,10 +41,10 @@ Marginal inference is accomplished by applying `Infer(params,model)` to a genera
 
 
 
-Using Javascript libraries
+Using JavaScript libraries
 ---------
 
-Functions from the Javascript environment that WebPPL is called from can be used in a WebPPL program, with a few restrictions. First, these external functions must be deterministic and cannot carry state from one call to another. (That is, the functions must be 'referentially transparent': calling obj.foo(args) must always return the same value when called with given arguments.) Second, external functions can't be called with a WebPPL function as an argument (that is, they can't be higher-order). Third, external functions must be invoked as the method of an object (indeed, this is the only use of object method invocation currently possible in WebPPL). So the use of `Math.log()` in the above example is allowed: it is a deterministic function invoked as a method of the `Math` object (which is a standard object in the Javascript global environment).
+Functions from the JavaScript environment that WebPPL is called from can be used in a WebPPL program, with a few restrictions. First, these external functions must be deterministic and cannot carry state from one call to another. (That is, the functions must be 'referentially transparent': calling obj.foo(args) must always return the same value when called with given arguments.) Second, external functions can't be called with a WebPPL function as an argument (that is, they can't be higher-order). Third, external functions must be invoked as the method of an object (indeed, this is the only use of object method invocation currently possible in WebPPL). So the use of `Math.log()` in the above example is allowed: it is a deterministic function invoked as a method of the `Math` object (which is a standard object in the JavaScript global environment).
 
 (note: some of this should move to, or be about packages??)
 
@@ -65,7 +65,7 @@ foo(5)
 
 
 
-Deviations from Javascript
+Deviations from JavaScript
 -----------
 
-This section documents a few common "gotchas" for those familiar with Javascript.
+This section documents a few common "gotchas" for those familiar with JavaScript.

--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -75,10 +75,10 @@ These macros will be visible to the WebPPL program which is been run
 or compiled, and to any WebPPL code within the same package. They will
 not be visible to WebPPL code in other packages.
 
-Javascript functions and libraries
+JavaScript functions and libraries
 ----------------------------------
 
-Any regular Javascript code within a package is made available in WebPPL
+Any regular JavaScript code within a package is made available in WebPPL
 as a global variable. The global variable takes the same name as the
 package except when the package name includes one or more ``-``
 characters. In such cases the name of the global variable is obtained by
@@ -94,7 +94,7 @@ For example, if the package ``my-package`` contains this file::
 Then the function ``myAdd`` will be available in WebPPL as
 ``myPackage.myAdd``.
 
-If your Javascript isn’t in an ``index.js`` file in the root of the
+If your JavaScript isn’t in an ``index.js`` file in the root of the
 package, you should indicate the entry point to your package by adding a
 ``main`` entry to ``package.json``. For example::
 
@@ -120,7 +120,7 @@ access WebPPL internals. Header files have access to the following:
 Let’s use the example of a function that makes the current address
 available in WebPPL:
 
-1. Write a Javascript file that exports a function. The function will be
+1. Write a JavaScript file that exports a function. The function will be
    called with the ``env`` container and should return an object
    containing the functions you want to use::
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,4 @@
-Quick start
+Quick Start
 ===========
 
 Install using `nodejs <http://nodejs.org>`_::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,7 @@
 Usage
 =====
 
-Running webppl programs::
+Running WebPPL programs::
 
     webppl examples/geometric.wppl
 
@@ -9,7 +9,7 @@ Seeding the random number generator::
 
     webppl examples/lda.wppl --random-seed 2344512342
 
-Compiling webppl programs to Javascript::
+Compiling WebPPL programs to JavaScript::
 
     webppl examples/geometric.wppl --compile --out geometric.js
 
@@ -17,12 +17,12 @@ The compiled file can be run using nodejs::
 
     node geometric.js
 
-To use webppl in web pages, include the `browser bundle
+To use WebPPL in web pages, include the `browser bundle
 <development/workflow.html#browser-version>`_::
 
     <script src="webppl.js"></script>
     <script>webppl.run(...)</script>
 
-We also provide an in-browser editor for webppl code. See the documentation for webppl-editor_
+We also provide an in-browser editor for WebPPL code. See the documentation for webppl-editor_
 
 .. _webppl-editor: https://github.com/probmods/webppl-editor


### PR DESCRIPTION
I left the big headings title cased - looked weird otherwise, and I read some advice somewhere to have the big headings capitalized like that.