### PR TITLE
Allow drift kernels to be specified in user code.

### DIFF
--- a/docs/distributions.rst
+++ b/docs/distributions.rst
@@ -68,12 +68,6 @@ Distributions
 
   `Wikipedia entry <https://en.wikipedia.org/wiki/Dirichlet_distribution>`__
 
-.. js:function:: DirichletDrift({alpha: ...})
-
-  * alpha: vector of concentration parameters *(>0)*
-
-  Drift version of Dirichlet. Drift kernels are used to narrow search during inference. Currently, the parameters guiding this narrowing are hard-coded.
-
 .. js:function:: Discrete({ps: ...})
 
   * ps: array or vector of probabilities *(in [0,1])*
@@ -107,13 +101,6 @@ Distributions
   Distribution over reals.
 
   `Wikipedia entry <https://en.wikipedia.org/wiki/Normal_distribution>`__
-
-.. js:function:: GaussianDrift({mu: ..., sigma: ...})
-
-  * mu: mean (real)
-  * sigma: standard deviation (real) *(>0)*
-
-  Drift version of Gaussian. Drift kernels are used to narrow search during inference. Currently, the parameters guiding this narrowing are hard-coded.
 
 .. js:function:: LogisticNormal({mu: ..., sigma: ...})
 
@@ -178,12 +165,4 @@ Distributions
   Continuous uniform distribution over ``[a, b]``
 
   `Wikipedia entry <https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)>`__
-
-.. js:function:: UniformDrift({a: ..., b: ..., r: ...})
-
-  * a: lower bound (real)
-  * b: upper bound (real > a)
-  * r: drift kernel radius
-
-  Drift version of Uniform. Drift kernels are used to narrow search during inference. UniformDrift proposes from a symmetric window around the current value ``x``, ``[x-r, x+r]``.
 

--- a/docs/driftKernels.rst
+++ b/docs/driftKernels.rst
@@ -43,10 +43,6 @@ statement using the ``driftKernel`` option like so::
 
   sample(dist, {driftKernel: kernelFn});
 
-Note that the :ref:`distribution <distributions>` returned by the
-drift kernel function ``kernelFn`` should have support everywhere
-``dist`` has support.
-
 To use our ``gaussianKernel`` with a Cauchy random choice we would
 write::
 

--- a/docs/driftKernels.rst
+++ b/docs/driftKernels.rst
@@ -1,0 +1,68 @@
+.. _driftKernels:
+
+Drift Kernels
+=============
+
+Introduction
+------------
+
+The default behavior of MH based :ref:`inference <inference>`
+algorithms is to generate proposals by sampling from the prior. This
+strategy is generally applicable, but can be inefficient when the
+prior places little mass in areas where the posterior mass in
+concentrated. In such situations the algorithm may make many proposals
+before a move is accepted.
+
+An alternative is to sample proposals from a distribution centered on
+the previous value of the random choice to which we are proposing.
+This produces a random walk that allows inference to find and explore
+areas of high probability in a more systematic way. This type of
+proposal distribution is called a drift kernel.
+
+This strategy has the potential to perform better than sampling from
+the prior. However, the width of the proposal distribution affects the
+efficiency of inference, and will often need tuning by hand to obtain
+good results.
+
+Specifying drift kernels
+------------------------
+
+A drift kernel is represented in a WebPPL program as a function that
+maps from the previous value taken by a random choice to a
+:ref:`distribution <distributions>`.
+
+For example, to propose from a Gaussian distribution centered on the
+previous value we can use the following function::
+
+  var gaussianKernel = function(prevVal) {
+    return Gaussian({mu: prevVal, sigma: .1});
+  };
+
+This function can be used to specify a drift kernel at any ``sample``
+statement using the ``driftKernel`` option like so::
+
+  sample(dist, {driftKernel: kernelFn});
+
+Note that the :ref:`distribution <distributions>` returned by the
+drift kernel function ``kernelFn`` should have support everywhere
+``dist`` has support.
+
+To use our ``gaussianKernel`` with a Cauchy random choice we would
+write::
+
+  sample(Cauchy(params), {driftKernel: gaussianKernel});
+
+Helpers
+-------
+
+A number of built-in helpers provide sensible drift kernels for
+frequently used distributions. These typically take the same
+parameters as the :ref:`distribution <distributions>` from which they
+sample, plus an extra parameter to control the width of the proposal
+distribution.
+
+.. js:function:: gaussianDrift({mu: ..., sigma: ..., width: ...})
+
+.. js:function:: dirichletDrift({alpha: ..., concentration: ...})
+
+.. js:function:: uniformDrift({a: ..., b: ..., width: ...})

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    optimization
    distributions
    guides
+   driftKernels
    header
    arrays
    tensors

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -153,6 +153,9 @@ The following kernels are available:
 
    Implements single site Metropolis-Hastings. [wingate11]_
 
+   This kernel makes use of any :ref:`drift kernels <driftKernels>`
+   specified in the model.
+
 Example usage::
 
     Infer({method: 'MCMC', kernel: 'MH'}, model);
@@ -190,6 +193,9 @@ Incremental MH
 .. js:function:: Infer({method: 'incrementalMH'[, ...]}, model)
 
    This method performs inference using C3. [ritchie15]_
+
+   This method makes use of any :ref:`drift kernels <driftKernels>`
+   specified in the model.
 
    The following options are supported:
 

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -21,8 +21,6 @@
 //   discrete distributions with finite support) or an object with
 //   'lower' and 'upper' properties (for continuous distributions with
 //   bounded support).
-// - dist.driftKernel(prevVal) is a distribution for making mh
-//   proposals conditioned on the previous value
 //
 // All distributions should also satisfy the following:
 //
@@ -137,11 +135,10 @@ var noHMC = {
   noHMC: true
 };
 
-var methodNames = ['sample', 'score', 'support', 'print', 'driftKernel', 'base', 'transform'];
+var methodNames = ['sample', 'score', 'support', 'print', 'base', 'transform'];
 
 function makeDistributionType(options) {
   options = util.mergeDefaults(options, {
-    parent: Distribution,
     mixins: []
   });
 
@@ -186,10 +183,9 @@ function makeDistributionType(options) {
     }
   };
 
-  dist.prototype = Object.create(options.parent.prototype);
+  dist.prototype = Object.create(Distribution.prototype);
   dist.prototype.constructor = dist;
 
-  // Note that meta-data is not inherited from the parent.
   dist.prototype.meta = _.pick(options, 'name', 'desc', 'params', 'internal', 'wikipedia');
 
   _.extendOwn.apply(_, [dist.prototype].concat(options.mixins));
@@ -228,29 +224,6 @@ var Uniform = makeDistributionType({
     return { lower: this.params.a, upper: this.params.b };
   }
 });
-
-var UniformDrift = makeDistributionType({
-  name: 'UniformDrift',
-  desc: 'Drift version of Uniform. ' +
-      'Drift kernels are used to narrow search during inference. ' +
-      'UniformDrift proposes from a symmetric window around the current value ``x``, ``[x-r, x+r]``.',
-  params: [{name: 'a', desc: 'lower bound (real)'},
-           {name: 'b', desc: 'upper bound (real > a)'},
-           {name: 'r', desc: 'drift kernel radius'}],
-  parent: Uniform,
-  driftKernel: function(prevVal) {
-    // propose from the window [prevVal - r, prevVal + r]
-    // where r is the proposal radius (defaults to 0.1)
-
-    var r = this.params.r === undefined ? 0.1 : this.params.r;
-
-    return new Uniform({
-      a: Math.max(prevVal - r, this.params.a),
-      b: Math.min(prevVal + r, this.params.b)
-    });
-  }
-});
-
 
 var Bernoulli = makeDistributionType({
   name: 'Bernoulli',
@@ -393,22 +366,6 @@ var Gaussian = makeDistributionType({
     var mu = this.params.mu;
     var sigma = this.params.sigma;
     return ad.scalar.add(ad.scalar.mul(sigma, x), mu);  }
-});
-
-
-
-
-var GaussianDrift = makeDistributionType({
-  name: 'GaussianDrift',
-  desc: 'Drift version of Gaussian. ' +
-      'Drift kernels are used to narrow search during inference. ' +
-      'Currently, the parameters guiding this narrowing are hard-coded.',
-  params: [{name: 'mu', desc: 'mean (real)'},
-           {name: 'sigma', desc: 'standard deviation (real)', domain: gt(0)}],
-  parent: Gaussian,
-  driftKernel: function(curVal) {
-    return new Gaussian({mu: curVal, sigma: this.params.sigma * 0.7});
-  }
 });
 
 
@@ -1196,22 +1153,6 @@ var Dirichlet = makeDistributionType({
 });
 
 
-
-var DirichletDrift = makeDistributionType({
-  name: 'DirichletDrift',
-  desc: 'Drift version of Dirichlet. ' +
-      'Drift kernels are used to narrow search during inference. ' +
-      'Currently, the parameters guiding this narrowing are hard-coded.',
-  parent: Dirichlet,
-  params: [{name: 'alpha', desc: 'vector of concentration parameters', domain: gt(0)}],
-  driftKernel: function(prevVal) {
-    var concentration = 10;
-    var alpha = prevVal.mul(10);
-    return new Dirichlet({alpha: alpha});
-  }
-});
-
-
 function discreteSample(theta) {
   var thetaSum = util.sum(theta);
   var x = util.random() * thetaSum;
@@ -1333,12 +1274,10 @@ var Delta = makeDistributionType({
 module.exports = {
   // distributions
   Uniform: Uniform,
-  UniformDrift: UniformDrift,
   Bernoulli: Bernoulli,
   MultivariateBernoulli: MultivariateBernoulli,
   RandomInteger: RandomInteger,
   Gaussian: Gaussian,
-  GaussianDrift: GaussianDrift,
   MultivariateGaussian: MultivariateGaussian,
   DiagCovGaussian: DiagCovGaussian,
   TensorGaussian: TensorGaussian,
@@ -1352,7 +1291,6 @@ module.exports = {
   Multinomial: Multinomial,
   Poisson: Poisson,
   Dirichlet: Dirichlet,
-  DirichletDrift: DirichletDrift,
   Marginal: Marginal,
   Categorical: Categorical,
   Delta: Delta,

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -6,10 +6,8 @@ defineDistConstructors(
     Bernoulli
     MultivariateBernoulli
     Uniform
-    UniformDrift
     RandomInteger
     Gaussian
-    GaussianDrift
     MultivariateGaussian
     DiagCovGaussian
     TensorGaussian
@@ -22,7 +20,6 @@ defineDistConstructors(
     Multinomial
     Poisson
     Dirichlet
-    DirichletDrift
     LogisticNormal
     Categorical
     Delta);
@@ -147,6 +144,38 @@ var serializeDist = function(d) {
 
 var deserializeDist = function(JSONString) {
   return dists.deserialize(JSONString);
+};
+
+// Drift kernel helpers
+
+var gaussianDrift = function(params) {
+  return sample(Gaussian(_.omit(params, 'width')), {
+    driftKernel: function(prevVal) {
+      var width = _.has(params, 'width') ? params.width : params.sigma * 0.7;
+      return Gaussian({mu: prevVal, sigma: width});
+    }
+  });
+};
+
+var dirichletDrift = function(params) {
+  return sample(Dirichlet(_.omit(params, 'concentration')), {
+    driftKernel: function(prevVal) {
+      var c = _.has(params, 'concentration') ? params.concentration : 10;
+      var alpha = T.mul(prevVal, c);
+      return Dirichlet({alpha: alpha});
+    }
+  });
+};
+
+var uniformDrift = function(params) {
+  return sample(Uniform(_.omit(params, 'width')), {
+    driftKernel: function(prevVal) {
+      var width = _.has(params, 'width') ? params.width : 0.1;
+      var a = Math.max(params.a, prevVal - width);
+      var b = Math.min(params.b, prevVal + width);
+      return Uniform({a: a, b: b});
+    }
+  });
 };
 
 // XRPs

--- a/src/inference/driftKernel.js
+++ b/src/inference/driftKernel.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var util = require('../util');
+
 module.exports = function(env) {
 
   var driftKernelCoroutine = {
@@ -42,8 +44,19 @@ module.exports = function(env) {
     };
   }
 
+  // We show a warning when the score of a drift proposal is -Infinity
+  // as it's likely this is caused by a bug in the drift kernel
+  // function.
+  function proposalWarning(priorDist) {
+    util.warn(
+        'Proposal from drift kernel has zero probability under ' +
+        priorDist.meta.name +
+        ' prior.');
+  }
+
   return {
-    getProposalDist: getProposalDist
+    getProposalDist: getProposalDist,
+    proposalWarning: proposalWarning
   };
 
 };

--- a/src/inference/hmckernel.js
+++ b/src/inference/hmckernel.js
@@ -41,7 +41,7 @@ module.exports = function(env) {
     env.coroutine = this;
   }
 
-  HMCKernel.prototype.sample = function(s, k, a, dist) {
+  HMCKernel.prototype.sample = function(s, k, a, dist, options) {
     var prevChoice = this.prevTrace.findChoice(a);
     if (!prevChoice) {
       throw new Error('HMC does not support structural continuous variables.');
@@ -82,7 +82,7 @@ module.exports = function(env) {
       val = prevChoice.val;
     }
 
-    this.trace.addChoice(dist, val, a, s, k);
+    this.trace.addChoice(dist, val, a, s, k, options);
     return k(s, val);
   };
 

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -119,9 +119,6 @@ module.exports = function(env) {
     // Bail out early if we know proposal will be rejected
     if (this.score === -Infinity) {
       tabbedlog(4, this.depth, 'score became -Infinity; bailing out early');
-      if (_.has(this.args[0], 'driftKernel')) {
-        drift.proposalWarning(this.dist);
-      }
       return this.coroutine.exit();
     } else {
       return this.kontinue();
@@ -171,6 +168,9 @@ module.exports = function(env) {
             updateProperty(this, 'store', _.clone(this.store));
             updateProperty(this, 'val', newval);
             this.rescore();
+            if (this.score === -Infinity && _.has(sampleOptions, 'driftKernel')) {
+              drift.proposalWarning(this.dist);
+            }
 
             return drift.getProposalDist(
                 s, this.address, this.dist, sampleOptions, newval,

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -13,7 +13,7 @@ var MaxAggregator = require('../aggregation/MaxAggregator');
 
 module.exports = function(env) {
 
-  var getProposalDist = require('./driftKernel')(env).getProposalDist;
+  var drift = require('./driftKernel')(env);
 
   // ------------------------------------------------------------------
 
@@ -119,6 +119,9 @@ module.exports = function(env) {
     // Bail out early if we know proposal will be rejected
     if (this.score === -Infinity) {
       tabbedlog(4, this.depth, 'score became -Infinity; bailing out early');
+      if (_.has(this.args[0], 'driftKernel')) {
+        drift.proposalWarning(this.dist);
+      }
       return this.coroutine.exit();
     } else {
       return this.kontinue();
@@ -152,7 +155,7 @@ module.exports = function(env) {
     var oldval = this.val;
     var sampleOptions = this.args[0];
 
-    return getProposalDist(
+    return drift.getProposalDist(
         this.store, this.address, this.dist, sampleOptions, oldval,
         function(s, fwdPropDist) {
 
@@ -169,7 +172,7 @@ module.exports = function(env) {
             updateProperty(this, 'val', newval);
             this.rescore();
 
-            return getProposalDist(
+            return drift.getProposalDist(
                 s, this.address, this.dist, sampleOptions, newval,
                 function(s, rvsPropDist) {
                   //var rvsPropDist = this.dist.driftKernel ? this.dist.driftKernel(newval) : this.dist;

--- a/src/inference/incrementalmh.js
+++ b/src/inference/incrementalmh.js
@@ -175,7 +175,6 @@ module.exports = function(env) {
             return drift.getProposalDist(
                 s, this.address, this.dist, sampleOptions, newval,
                 function(s, rvsPropDist) {
-                  //var rvsPropDist = this.dist.driftKernel ? this.dist.driftKernel(newval) : this.dist;
                   this.coroutine.rvsPropLP = rvsPropDist.score(oldval);
                   this.coroutine.fwdPropLP = fwdPropDist.score(newval);
                   tabbedlog(1, this.depth, 'initial rvsPropLP:', this.coroutine.rvsPropLP,

--- a/src/inference/initialize.js
+++ b/src/inference/initialize.js
@@ -31,10 +31,10 @@ module.exports = function(env) {
     return this.trace.continue();
   };
 
-  Initialize.prototype.sample = function(s, k, a, dist) {
+  Initialize.prototype.sample = function(s, k, a, dist, options) {
     var _val = dist.sample();
     var val = this.ad && dist.isContinuous ? ad.lift(_val) : _val;
-    this.trace.addChoice(dist, val, a, s, k);
+    this.trace.addChoice(dist, val, a, s, k, options);
     return k(s, val);
   };
 

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -100,17 +100,17 @@ module.exports = function(env) {
         this.fwdProposalDist = fwdProposalDist;
         this.revProposalDist = revProposalDist;
 
-        return this.addChoiceToTrace(s, k, a, dist, options, val);
+        return this.addChoiceToTrace(s, k, a, dist, options, val, true);
 
       }.bind(this));
 
     }.bind(this));
   };
 
-  MHKernel.prototype.addChoiceToTrace = function(s, k, a, dist, options, val) {
+  MHKernel.prototype.addChoiceToTrace = function(s, k, a, dist, options, val, atResample) {
     this.trace.addChoice(dist, val, a, s, k, options);
     if (ad.value(this.trace.score) === -Infinity) {
-      if (_.has(options, 'driftKernel')) {
+      if (atResample && _.has(options, 'driftKernel')) {
         drift.proposalWarning(dist);
       }
       return this.finish(this.oldTrace, false);

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -86,7 +86,7 @@ module.exports = function(env) {
     var val = this.adRequired && dist.isContinuous ? ad.lift(_val) : _val;
     // Optimization: Choices are not required for PF without rejuvenation.
     if (this.performRejuv || this.saveTraces) {
-      particle.trace.addChoice(dist, val, a, s, k);
+      particle.trace.addChoice(dist, val, a, s, k, options);
     }
     return k(s, val);
   };

--- a/src/trace.js
+++ b/src/trace.js
@@ -50,7 +50,7 @@ Trace.prototype.continue = function() {
   }
 };
 
-Trace.prototype.addChoice = function(dist, val, address, store, continuation) {
+Trace.prototype.addChoice = function(dist, val, address, store, continuation, options) {
   // Called at sample statements.
   // Adds the choice to the DB and updates current score.
 
@@ -63,6 +63,7 @@ Trace.prototype.addChoice = function(dist, val, address, store, continuation) {
     k: continuation,
     address: address,
     dist: dist,
+    options: options, // the options argument passed to sample
     // Record the score without adding the choiceScore. This is the score we'll
     // need if we regen from this choice.
     score: this.score,

--- a/tests/test-data/stochastic/models/gaussianDrift.wppl
+++ b/tests/test-data/stochastic/models/gaussianDrift.wppl
@@ -2,8 +2,8 @@ var xs = [0, 1, 2, 3];
 var ys = [0, 1, 4, 6];
 
 var model = function() {
-  var m = sample(GaussianDrift({mu: 0, sigma: 2}));
-  var b = sample(GaussianDrift({mu: 0, sigma: 2}));
+  var m = gaussianDrift({mu: 0, sigma: 2});
+  var b = gaussianDrift({mu: 0, sigma: 2});
 
   var sigma = gamma(1, 1);
 

--- a/tests/test-data/stochastic/models/uniformDrift.wppl
+++ b/tests/test-data/stochastic/models/uniformDrift.wppl
@@ -1,5 +1,5 @@
 var model = function() {
-  var x = sample(UniformDrift({a: -3, b: 6, r: 0.2}));
+  var x = uniformDrift({a: -3, b: 6, width: 0.2});
   condition(x >= 0);
 
   return x;


### PR DESCRIPTION
After this change we no longer have to add new distributions for each distribution/drift kernel pair we'd like to use. Instead, we can write things like:

```js
sample(Cauchy(params), {
  driftKernel: function(prevVal) {
    return Gaussian({mu: prevVal, sigma: width});
  }
});
```

A lot of the complexity in the implementation comes from having to call the cps drift kernel functions from hand written cps inference code, but it's not too bad.

I've added helpers to the header that mimic the behavior of the old drift distributions.

Closes #119. Closes #231. Partially addresses #308 (added docs).

@dritchie has already [looked over](https://github.com/probmods/webppl/issues/119#issuecomment-232826013) the incremental MH bits.