### PR TITLE
Change error for missing return value.

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -13,12 +13,18 @@ function makeGenvar() {
   };
 }
 
-function fail(message, node) {
-  return function() {
-    console.log(node);
-    console.log(message);
-    throw new Error(message);
-  };
+function fail(message, node, simpleMessage) {
+  if (simpleMessage === true) {
+    return function() {
+      throw message;
+    }
+  } else {
+    return function() {
+      console.log(node);
+      console.log(message);
+      throw new Error(message);
+    };
+  }
 }
 
 // a clause matches a node type and calls a destructor with constituents
@@ -114,7 +120,7 @@ function returnify(nodes) {
       clause(Syntax.ReturnStatement, function(argument) {
         return build.returnStatement(argument);
       })
-    ], fail('returnify', nodes[nodes.length - 1]));
+    ], fail('Error: programs must end with a return value. Try adding a return statement at the end of your program (the return keyword is optional).', nodes[nodes.length - 1], true));
 
     return nodes;
   }


### PR DESCRIPTION
For #489.

- Does this change errors for other problems?
- Is the way I handled `fail()` hacky?
- The message line is too long to pass `grunt` and there was an unrelated error, so I'm not sure what to do about that:

```
Testing test-inference.js......................................MultivariateBernoulli({ ps: 
   Tensor {
     dims: [ 2, 1 ],
     length: 2,
     data: Float64Array { '0': 0.5, '1': 0.1 } } })
Exception: Error: Enumerate can only be used with distributions that have finite support.
F..........................................................................................................................................................................................................
>> Enumerate - multivariateBernoulli
>> Error: Enumerate can only be used with distributions that have finite support.
>> at getSupport (src/inference/enumerate.js:44:19)
>> at Enumerate.sample (src/inference/enumerate.js:54:23)
>> at env.sample (src/header.js:82:26)
>> at eval (eval at <anonymous> (src/main.js:220:10), <anonymous>:75:44)
>> at /usr/local/lib/node_modules/webppl/src/util.js:51:13
>> at /usr/local/lib/node_modules/webppl/src/util.js:14:14
>> at eval (eval at <anonymous> (src/main.js:220:10), <anonymous>:5:13)
>> at /usr/local/lib/node_modules/webppl/src/main.js:220:48
>> at Object.timeif (src/util.js:283:37)
>> at Object.run (src/main.js:219:8)
```