### PR TITLE
Don't inc. accepted count when no proposal made.

### DIFF
--- a/src/inference/hmckernel.js
+++ b/src/inference/hmckernel.js
@@ -100,6 +100,15 @@ module.exports = function(env) {
 
   HMCKernel.prototype.run = function() {
 
+    // Immediately return from coroutine if there are no continuous
+    // random choices to propose to.
+    var numChoices = this.oldTrace.choices.reduce(function(acc, c) {
+      return acc + (c.dist.isContinuous ? 1 : 0);
+    }, 0);
+    if (numChoices === 0) {
+      return this.continue(this.oldTrace);
+    }
+
     // Zero derivatives left over from previous HMC iterations, or
     // from the rejuvenation of a particle which shares parts of the
     // ad graph which this trace.
@@ -234,6 +243,10 @@ module.exports = function(env) {
         total: oldInfo.total + 1
       };
     }
+    return this.continue(trace);
+  };
+
+  HMCKernel.prototype.continue = function(trace) {
     env.coroutine = this.coroutine;
     return this.cont(trace);
   };

--- a/src/inference/mcmc.js
+++ b/src/inference/mcmc.js
@@ -113,8 +113,8 @@ module.exports = function(env) {
   }
 
   function formatOutput(trace, i) {
-    var ratio = (trace.info.accepted / trace.info.total).toFixed(4);
-    return 'Iteration: ' + i + ' | Acceptance ratio: ' + ratio;
+    var ratio = (trace.info.total === 0) ? 0 : trace.info.accepted / trace.info.total;
+    return 'Iteration: ' + i + ' | Acceptance ratio: ' + ratio.toFixed(4);
   }
 
   function makeVMCallbackForPlatform() {

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -37,7 +37,9 @@ module.exports = function(env) {
   MHKernel.prototype.run = function() {
     this.regenFrom = this.sampleRegenChoice(this.oldTrace);
     if (this.regenFrom < 0) {
-      return this.finish(this.oldTrace, true);
+      // Immediately return from coroutine if there are no random
+      // choices to propose to.
+      return this.continue(this.oldTrace);
     }
     env.query.clear();
     this.trace = this.oldTrace.upto(this.regenFrom);
@@ -114,6 +116,10 @@ module.exports = function(env) {
         total: oldInfo.total + 1
       };
     }
+    return this.continue(trace);
+  };
+
+  MHKernel.prototype.continue = function(trace) {
     env.coroutine = this.coroutine;
     return this.cont(trace);
   };


### PR DESCRIPTION
After this change both the MH and HMC kernels immediately return the old trace without incrementing the acceptance ratio counts when there are no random choices to propose to.

Because it's now possible for the number of proposals made to be zero, we check for this when computing the acceptance ratio to avoid division by zero.

Closes #575.