### PR TITLE
Append "undefined" to programs without a final expression

### DIFF
--- a/src/syntax.js
+++ b/src/syntax.js
@@ -95,7 +95,7 @@ function returnify(nodes) {
     return nodes;
   }
   else {
-    nodes[nodes.length - 1] = match(nodes[nodes.length - 1], [
+    var returnNode = match(nodes[nodes.length - 1], [
       clause(Syntax.BlockStatement, function(body) {
         return build.blockStatement(returnify(body));
       }),
@@ -114,7 +114,13 @@ function returnify(nodes) {
       clause(Syntax.ReturnStatement, function(argument) {
         return build.returnStatement(argument);
       })
-    ], fail('returnify', nodes[nodes.length - 1]));
+    ], function() { return; });
+
+    if (returnNode) {
+      nodes[nodes.length - 1] = returnNode;
+    } else {
+      nodes = nodes.concat(build.returnStatement(build.identifier('undefined')));
+    }
 
     return nodes;
   }

--- a/tests/test-transforms.js
+++ b/tests/test-transforms.js
@@ -365,6 +365,18 @@ var tests = {
 
   ],
 
+  testNoFinalExpression: [
+
+    { name: 'testEmptyProgram',
+      code: '',
+      expected: undefined },
+
+    { name: 'testVariableDeclaration',
+      code: 'var x = 1;',
+      expected: undefined }
+
+  ],
+
   testDebuggerStatement: [
 
     { name: 'test',


### PR DESCRIPTION
In #489 @chrisranderson suggested we return some default value rather than throw an error. This seems worth exploring to me, so this change adds the line `undefined` to the end of any program that would previously have throw the returnify error. I'm happy to close this submit a PR that just changes the current error message if this is risky/controversial, etc.

Things I like about it:

1. This feels pretty natural to me. I don't think seeing `undefined` in the output will block users' progress.
2. I occasionally find myself with a program that doesn't end with an expression that I do want to run. In such cases I tend to write `'done'` at the end of the program, which is a tiny inconvenience that this would remove.

One concern is that users may not realise that we print the value of last expression and use `display` instead:

```js
var a = 0;
display(a);
```

The hope is that because the above program will still have `undefined` as the last line of the output, that this will be enough to help people figure out what's happening.

If not, perhaps we could print a warning but still run the program. (Something like: "Note: This program will evaluate to undefined because the last statement is not an expression.")