### PR TITLE
Switch default optimization method to adam.

### DIFF
--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -65,7 +65,7 @@ Optimize
       example usage. Additional method specific options are available,
       see the `adnn optimization module`_ for details.
 
-      Default: ``'adagrad'``
+      Default: ``'adam'``
 
    .. describe:: estimator
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "adnn": "^1.1.5",
+    "adnn": "^1.1.6",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "colors": "^1.1.2",

--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -26,7 +26,7 @@ module.exports = function(env) {
   function Optimize(s, k, a, wpplFn, options) {
     options = util.mergeDefaults(options, {
       params: {},
-      optMethod: 'adagrad',
+      optMethod: 'adam',
       estimator: 'ELBO',
       steps: 1,
       clip: false,              // false = no clipping, otherwise specifies threshold.


### PR DESCRIPTION
Closes #548.

Most of the inference tests for `optimize` specify an optimization method and won't be affected by this. One of the inference tests will switch from using adagrad to adam as a result of this change. I expect it to continue passing reliably.