### PR TITLE
Un-lift score before -Infinity check in MCMC init.

### DIFF
--- a/src/inference/initialize.js
+++ b/src/inference/initialize.js
@@ -39,7 +39,7 @@ module.exports = function(env) {
   };
 
   Initialize.prototype.factor = function(s, k, a, score) {
-    if (score === -Infinity) {
+    if (ad.value(score) === -Infinity) {
       return this.fail();
     }
     this.trace.score = ad.scalar.add(this.trace.score, score);


### PR DESCRIPTION
When using AD (i.e. when initializing a trace for HMC) then score can be lifted.

Closes #598.