### PR TITLE
add observe

### DIFF
--- a/src/header.wppl
+++ b/src/header.wppl
@@ -547,6 +547,15 @@ var condition = function(bool) {
   factor(bool ? 0 : -Infinity);
 };
 
+var observe = function(dist, val) {
+  if(val !== undefined) {
+    factor(dist.score(val));
+    return val
+  } else {
+    return sample(dist)
+  }
+};
+
 var MH = function(wpplFn, samples, burn) {
   return MCMC(wpplFn, { samples: samples, burn: burn });
 };

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -548,11 +548,11 @@ var condition = function(bool) {
 };
 
 var observe = function(dist, val) {
-  if(val !== undefined) {
+  if (val !== undefined) {
     factor(dist.score(val));
-    return val
+    return val;
   } else {
-    return sample(dist)
+    return sample(dist);
   }
 };
 


### PR DESCRIPTION
Add `observe(dist,val)` helper to header. It acts as `factor(dist.score(val))` when `val` is defined and `sample(dist)` when it isn't. Addresses #602.

