### PR TITLE
Fix rejection docs

### DIFF
--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -48,8 +48,9 @@ Rejection sampling
 
    .. describe:: maxScore
 
-      An upper bound on the total factor score per-execution. Only
-      required for incremental mode.
+      An upper bound on the total factor score per-execution.
+
+      Default: ``0``
 
    .. describe:: incremental
 
@@ -59,11 +60,8 @@ Rejection sampling
 
    Incremental mode improves efficiency by rejecting samples before
    execution reaches the end of the program where possible. This
-   requires:
-
-   * The ``maxScore`` argument to be given, with ``maxScore <= 0``.
-   * Every call to ``factor(score)`` in the program (across all
-     possible executions) to have ``score <= 0``.
+   requires every call to ``factor(score)`` in the program (across all
+   possible executions) to have ``score <= 0``.
 
    Example usage::
 

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -37,8 +37,8 @@ module.exports = function(env) {
       throw new Error('samples should be a positive integer.');
     }
 
-    if (this.incremental) {
-      assert(this.maxScore <= 0, 'maxScore cannot be positive for incremental rejection.');
+    if (this.incremental && this.maxScore > 0) {
+      util.warn('Rejection: Reduce maxScore to zero for better performance.');
     }
   }
 


### PR DESCRIPTION
This fixes a problem or two with the rejection docs.

I've also relaxed the error thrown when `maxScore` is `> 0` when using incremental mode, as this is inefficient but won't produce incorrect results. That fact that it was presented in a way that made it sound like a correctness issue confused me when I was trying to (re)understand the code.