### PR TITLE
Add initialStore option to prepare()

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -224,9 +224,11 @@ function wrapRunner(baseRunner, handlers) {
   return runner;
 }
 
+
 function prepare(codeAndAssets, k, options) {
   options = util.mergeDefaults(options, {
-    errorHandlers: []
+    errorHandlers: [],
+    initialStore: {}
   });
 
   var currentAddress = {value: undefined};
@@ -241,7 +243,7 @@ function prepare(codeAndAssets, k, options) {
   var runner = wrapRunner(baseRunner, allErrorHandlers);
 
   var run = function() {
-    eval.call(global, codeAndAssets.code)(currentAddress)(runner)({}, k, '');
+    eval.call(global, codeAndAssets.code)(currentAddress)(runner)(options.initialStore, k, '');
   };
 
   return {run: run, runner: runner};


### PR DESCRIPTION
Back when the running pipeline was just `compile`-`run`, we were able to control the initial contents of `globalStore` when calling `run` (this was a useful mechanism for things like passing data to precompiled webppl programs).

Now that the pipeline is `compile`-`prepare`-`run`, we've lost that ability; this PR adds an `initialStore` option that revives it.