### PR TITLE
Integrate new adnn changes

### DIFF
--- a/docs/functions/tensors.rst
+++ b/docs/functions/tensors.rst
@@ -26,6 +26,17 @@ Creation
 
      Matrix([[1, 2], [3, 4]])
 
+.. js:function:: Tensor(dims, arr)
+
+   :param array dims: array of dimension sizes
+   :param array arr: array of values
+
+   Creates a tensor with dimension ``dims`` out of a flat array ``arr``.
+
+   Example::
+
+     Tensor([2, 2, 2], [1, 2, 3, 4, 5, 6, 7, 8])
+
 .. js:function:: zeros(dims)
 
    :param array dims: dimension of tensor
@@ -48,76 +59,7 @@ Creation
 
      ones([10, 1])
 
-Arithmetic
+Operations
 ----------
 
-The following functions operate element-wise. The functions with two
-parameters accept either a tensor or a scalar as their second
-argument.
-
-.. js:function:: T.add(x, y)
-
-   :param tensor x:
-   :param tensor y:
-
-   Element-wise addition.
-
-.. js:function:: T.sub(x, y)
-
-   :param tensor x:
-   :param tensor y:
-
-   Element-wise subtraction.
-
-.. js:function:: T.mul(x, y)
-
-   :param tensor x:
-   :param tensor y:
-
-   Element-wise multiplication.
-
-.. js:function:: T.div(x, y)
-
-   :param tensor x:
-   :param tensor y:
-
-   Element-wise division.
-
-.. js:function:: T.neg(x)
-
-   :param tensor x:
-
-   Element-wise negation.
-
-Linear algebra
---------------
-
-.. js:function:: T.dot(x, y)
-
-   :param matrix x:
-   :param matrix y:
-
-   Matrix multiplication.
-
-Indexing
---------
-
-.. js:function:: T.range(x, start, end)
-
-   :param tensor x:
-   :param integer start:
-   :param integer end:
-
-.. js:function:: T.get(x, index)
-
-   :param tensor x:
-   :param integer index:
-
-Reshaping
----------
-
-.. js:function:: T.transpose(x)
-
-   :param matrix x:
-
-   Matrix transpose.
+WebPPL inherits its Tensor functionality from `adnn <https://github.com/dritchie/adnn>`_. It supports all of the tensor functions documented `here <https://github.com/dritchie/adnn/blob/master/ad/README.md#available-ad-primitive-functions>`_.

--- a/docs/functions/tensors.rst
+++ b/docs/functions/tensors.rst
@@ -62,4 +62,8 @@ Creation
 Operations
 ----------
 
-WebPPL inherits its Tensor functionality from `adnn <https://github.com/dritchie/adnn>`_. It supports all of the tensor functions documented `here <https://github.com/dritchie/adnn/blob/master/ad/README.md#available-ad-primitive-functions>`_.
+WebPPL inherits its Tensor functionality from `adnn <https://github.com/dritchie/adnn>`_. It supports all of the tensor functions documented `here <https://github.com/dritchie/adnn/blob/master/ad/README.md#available-ad-primitive-functions>`_. Specifically, the ``ad.tensor`` module (and all the functions it contains) are globally available in WebPPL. For convenience, WebPPL also aliases ``ad.tensor`` to ``T``, so you can write things like::
+
+    var x = Vector([1, 2, 3]);
+    var y = Vector([3, 4, 5]);
+    var x = T.dot(x, y);        // instead of ad.tensor.dot(x, y)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "adnn": "^1.1.6",
+    "adnn": "^1.1.8",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "colors": "^1.1.2",

--- a/src/ad.js
+++ b/src/ad.js
@@ -27,9 +27,6 @@ var valueRec = function(x) {
 
 ad.valueRec = valueRec;
 
-// Make `tensorEntry` available in webppl as `T.get`.
-ad.tensor.get = ad.tensorEntry;
-
 ad.tensor.logGamma = ad.newUnaryFunction({
   OutputType: Tensor,
   name: 'logGamma',

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -397,7 +397,7 @@ function mvGaussianScore(mu, cov, x) {
   return ad.scalar.mul(-0.5, ad.scalar.add(
     dLog2Pi, ad.scalar.add(
       logDetCov,
-      ad.tensorEntry(ad.tensor.dot(ad.tensor.dot(zT, prec), z), 0))));
+      ad.tensor.get(ad.tensor.dot(ad.tensor.dot(zT, prec), z), 0))));
 }
 
 
@@ -504,7 +504,7 @@ var DiagCovGaussian = makeDistributionType({
 var squishToProbSimplex = function(x) {
   // Map a d dimensional vector onto the d simplex.
   var d = ad.value(x).dims[0];
-  var u = ad.tensor.reshape(ad.tensor.concat(x, ad.scalarsToTensor(0)), [d + 1, 1]);
+  var u = ad.tensor.reshape(ad.tensor.concat(x, ad.tensor.fromScalars(0)), [d + 1, 1]);
   return ad.tensor.softmax(u);
 };
 
@@ -550,7 +550,7 @@ var LogisticNormal = makeDistributionType({
 
     var d = _mu.dims[0];
     var u = ad.tensor.reshape(ad.tensor.range(val, 0, d), [d, 1]);
-    var u_last = ad.tensorEntry(val, d);
+    var u_last = ad.tensor.get(val, d);
     var inv = ad.tensor.log(ad.tensor.div(u, u_last));
     var normScore = diagCovGaussianScore(mu, sigma, inv);
     return ad.scalar.sub(normScore, ad.tensor.sumreduce(ad.tensor.log(val)));
@@ -766,7 +766,7 @@ function discreteScoreVector(probs, val) {
   assert.ok(_probs.dims[1] === 1); // i.e. vector
   var d = _probs.dims[0];
   return inDiscreteSupport(val, d) ?
-      ad.scalar.log(ad.scalar.div(ad.tensorEntry(probs, val), ad.tensor.sumreduce(probs))) :
+      ad.scalar.log(ad.scalar.div(ad.tensor.get(probs, val), ad.tensor.sumreduce(probs))) :
       -Infinity;
 }
 

--- a/src/guide.js
+++ b/src/guide.js
@@ -52,7 +52,7 @@ function makeParam(paramSpec, paramName, baseName, env) {
 
   // Collapse tensor with dims=[1] to scalar.
   if (dims.length === 1 && dims[0] === 1) {
-    param = ad.tensorEntry(param, 0);
+    param = ad.tensor.get(param, 0);
   }
 
   return param;

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -638,7 +638,7 @@ var Infer = function(options, wpplFn) {
 
 // Convenience function to create scalar valued parameters.
 var scalarParam = function(mean, sd) {
-  return ad.tensorEntry(tensorParam([1], mean, sd), 0);
+  return ad.tensor.get(tensorParam([1], mean, sd), 0);
 };
 
 var param = function(a1, a2, a3) {
@@ -649,13 +649,17 @@ var param = function(a1, a2, a3) {
 // Convenience functions for building tensors out of scalars
 var Vector = function(arr) {
   var n = arr.length;
-  var t = ad.scalarsToTensor(arr);
+  var t = ad.tensor.fromScalars(arr);
   return ad.tensor.reshape(t, [n, 1]);
 };
 var Matrix = function(arr) {
   var n = arr.length;
   var m = arr[0].length;
-  var t = ad.scalarsToTensor(_.flatten(arr));
+  var t = ad.tensor.fromScalars(_.flatten(arr));
   return ad.tensor.reshape(t, [n, m]);
+};
+var Tensor = function(dims, arr) {
+  var t = ad.tensor.fromScalars(arr);
+  return ad.tensor.reshape(t, dims);
 };
 


### PR DESCRIPTION
I got tired of all the confusion/questions around "what can you / can't you do with tensors in WebPPL?," so I made a fairly small change to adnn that lets us point directly to adnn and say "everything in ad.tensor is usable, and for convenience, ad.tensor = T." Hopefully, this will:
 - Make it clearer what is/isn't supported by moving it all into one place.
 - Direct people to adnn (and not WebPPL) for tensor feature requests.