### PR TITLE
Bump adnn version to new major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "adnn": "^1.1.8",
+    "adnn": "^2.0.0",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "colors": "^1.1.2",


### PR DESCRIPTION
Keeps other WebPPL branches that still use the older version of adnn from versioning up past a breaking change.