### PR TITLE
Better parameterization of Discrete guide distributions

### DIFF
--- a/docs/primitive-distributions.txt
+++ b/docs/primitive-distributions.txt
@@ -65,7 +65,7 @@
 
 .. js:function:: Discrete({ps: ...})
 
-  * ps: array or vector of probabilities *(in [0,1])*
+  * ps: array or vector of probabilities *(>0)*
 
   Distribution over ``{0,1,...,ps.length-1}`` with P(i) proportional to ``ps[i]``
 

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -779,7 +779,7 @@ function discreteScoreArray(probs, val) {
 var Discrete = makeDistributionType({
   name: 'Discrete',
   desc: 'Distribution over ``{0,1,...,ps.length-1}`` with P(i) proportional to ``ps[i]``',
-  params: [{name: 'ps', desc: 'array or vector of probabilities', domain: interval(0, 1)}],
+  params: [{name: 'ps', desc: 'array or vector of probabilities', domain: gt(0)}],
   wikipedia: 'Categorical_distribution',
   mixins: [finiteSupport],
   sample: function() {

--- a/src/domain.js
+++ b/src/domain.js
@@ -17,8 +17,15 @@ function interval(a, b) {
   return new RealInterval(a, b);
 }
 
+function Simplex() {
+}
+
+var simplex = new Simplex();
+
 module.exports = {
+  RealInterval: RealInterval,
   gt: gt,
   lt: lt,
-  interval: interval
+  interval: interval,
+  simplex: simplex
 };

--- a/src/guide.js
+++ b/src/guide.js
@@ -6,7 +6,7 @@ var util = require('./util');
 var Tensor = require('./tensor');
 var ad = require('./ad');
 var dists = require('./dists');
-var gt = require('./domain').gt;
+var domains = require('./domain');
 
 var T = ad.tensor;
 
@@ -40,14 +40,22 @@ function independent(targetDist, sampleAddress, env) {
 function makeParam(paramSpec, paramName, baseName, env) {
   var dims = paramSpec.dims; // e.g. [2, 1]
   var domain = paramSpec.domain; // e.g. new RealInterval(0, Infinity)
-
   var name = baseName + paramName;
-  var param = registerParam(env, name, paramSpec.dims);
+
+  var viParamDim, squish;
+  if (domain) {
+    var ret = squishFn(domain, dims);
+    viParamDim = ret.dimsIn;
+    squish = ret.f;
+  } else {
+    viParamDim = dims;
+  }
+
+  var param = registerParam(env, name, viParamDim);
 
   // Apply squishing.
-  if (domain) {
-    // Assume that domain is a RealInterval.
-    param = squishFn(domain.a, domain.b)(param);
+  if (squish) {
+    param = squish(param);
   }
 
   // Collapse tensor with dims=[1] to scalar.
@@ -143,7 +151,7 @@ function dirichletSpec(targetDist) {
     type: dists.LogisticNormal,
     params: {
       mu: {param: {dims: [d, 1]}},
-      sigma: {param: {dims: [d, 1], domain: gt(0)}}
+      sigma: {param: {dims: [d, 1], domain: domains.gt(0)}}
     }
   };
 }
@@ -153,7 +161,7 @@ function tensorGaussianSpec(targetDist) {
     type: dists.TensorGaussian,
     params: {
       mu: {param: {dims: [1]}},
-      sigma: {param: {dims: [1], domain: gt(0)}},
+      sigma: {param: {dims: [1], domain: domains.gt(0)}},
       dims: {const: targetDist.params.dims}
     }
   };
@@ -166,7 +174,7 @@ function uniformSpec(targetDist) {
       a: {const: targetDist.params.a},
       b: {const: targetDist.params.b},
       mu: {param: {dims: [1]}},
-      sigma: {param: {dims: [1], domain: gt(0)}}
+      sigma: {param: {dims: [1], domain: domains.gt(0)}}
     }
   };
 }
@@ -178,7 +186,7 @@ function betaSpec(targetDist) {
       a: {const: 0},
       b: {const: 1},
       mu: {param: {dims: [1]}},
-      sigma: {param: {dims: [1], domain: gt(0)}}
+      sigma: {param: {dims: [1], domain: domains.gt(0)}}
     }
   };
 }
@@ -188,7 +196,7 @@ function gammaSpec(targetDist) {
     type: dists.IspNormal,
     params: {
       mu: {param: {dims: [1]}},
-      sigma: {param: {dims: [1], domain: gt(0)}}
+      sigma: {param: {dims: [1], domain: domains.gt(0)}}
     }
   };
 }
@@ -197,9 +205,34 @@ function softplus(x) {
   return T.log(T.add(T.exp(x), 1));
 }
 
-// Returns a function that maps a (potentially lifted) tensor of
-// (unbounded) reals to the interval [a,b] element-wise.
-function squishFn(a, b) {
+// Returns a function `f` that maps from tensors of unbounded reals to
+// tensors in `domain` of dimension `dimsOut`. The function `f` takes
+// a tensor of unbounded reals of dimension `dimsIn`.
+
+// Parameters:
+// domain: Output domain
+// dimsOut: Output dimension
+
+// Returns:
+// dimsIn: Input dimension
+// f: Squishing function
+
+function squishFn(domain, dimsOut) {
+  if (domain instanceof domains.RealInterval) {
+    return {dimsIn: dimsOut, f: squishToInterval(domain)};
+  } else if (domain === domains.simplex) {
+    if (dimsOut.length !== 2 || dimsOut[1] !== 1) {
+      throw new Error('Can only map vectors to the probability simplex.');
+    }
+    return {dimsIn: [dimsOut[0] - 1, 1], f: dists.squishToProbSimplex};
+  } else {
+    throw new Error('Unknown domain type.');
+  }
+}
+
+function squishToInterval(domain) {
+  var a = domain.a;
+  var b = domain.b;
   if (a === -Infinity) {
     return function(x) {
       var y = softplus(x);

--- a/src/guide.js
+++ b/src/guide.js
@@ -109,6 +109,8 @@ function spec(targetDist) {
     return gammaSpec(targetDist);
   } else if (targetDist instanceof dists.Beta) {
     return betaSpec(targetDist);
+  } else if (targetDist instanceof dists.Discrete) {
+    return discreteSpec(targetDist);
   } else {
     return defaultSpec(targetDist);
   }
@@ -197,6 +199,16 @@ function gammaSpec(targetDist) {
     params: {
       mu: {param: {dims: [1]}},
       sigma: {param: {dims: [1], domain: domains.gt(0)}}
+    }
+  };
+}
+
+function discreteSpec(targetDist) {
+  var d = ad.value(targetDist.params.ps).length;
+  return {
+    type: dists.Discrete,
+    params: {
+      ps: {param: {dims: [d, 1], domain: domains.simplex}}
     }
   };
 }


### PR DESCRIPTION
A `Discrete` guide distribution over `0, 1,..., n` is now parameterized by a vector of length `n` which is squished to the simplex.

Closes #636.

I've also made a small tweak to the docs to reflect the fact that `Discrete` accepts an unnormalized `ps`.