### PR TITLE
Attach the number of samples to Marginals

### DIFF
--- a/src/aggregation/CountAggregator.js
+++ b/src/aggregation/CountAggregator.js
@@ -21,13 +21,20 @@ function normalize(hist) {
   var totalCount = _.reduce(hist, function(acc, obj) {
     return acc + obj.count;
   }, 0);
-  return _.mapObject(hist, function(obj) {
-    return { val: obj.val, prob: obj.count / totalCount };
-  });
+  return {
+    totalCount: totalCount,
+    dist: _.mapObject(hist, function(obj) {
+      return { val: obj.val, prob: obj.count / totalCount };
+    })
+  };
 }
 
 CountAggregator.prototype.toDist = function() {
-  return new dists.Marginal({dist: normalize(this.hist)});
+  var normalized = normalize(this.hist);
+  return new dists.Marginal({
+    dist: normalized.dist,
+    numSamples: normalized.totalCount
+  });
 };
 
 module.exports = CountAggregator;


### PR DESCRIPTION
For some visualization methods (e.g., 2d heatmap), we need to know the number of samples that are backing a marginal distribution.

As far as I can tell, this information isn't stored anywhere, so I've modified `CountAggregator` to store it. Example:

```js
var mdist = Infer({method: 'MCMC', samples: 51},
      function() { return uniformDraw(_.range(10)) });

mdist.params.numSamples // => 51
```