### PR TITLE
Make uniformDraw([]) behave in inference

### DIFF
--- a/src/header.wppl
+++ b/src/header.wppl
@@ -143,7 +143,11 @@ var delta = function(arg) {
 
 var uniformDraw = function(arg) {
   var vs = util.isObject(arg) ? arg.vs : arg;
-  return vs[sample(RandomInteger({n: vs.length}))];
+  if (vs.length == 0) {
+    return undefined;
+  } else {
+    return vs[sample(RandomInteger({n: vs.length}))];
+  }
 };
 
 var serializeDist = function(d) {


### PR DESCRIPTION
Outside of inference, `uniformDraw([])` returns `undefined`. Within `Enumerate`, though, it causes an error because the support is empty.

This PR makes the behavior more consistent inside and outside of inference by immediately returning `undefined` if the input array has length 0.