### PR TITLE
mapData - docs and fix return value when sub-sampling data

### DIFF
--- a/docs/functions/arrays.rst
+++ b/docs/functions/arrays.rst
@@ -10,6 +10,34 @@ Arrays
 
       map(function(x) { return x + 1; }, [0, 1, 2]); // => [1, 2, 3]
 
+.. js:function:: mapData({data: arr[, batchSize: n]}, fn)
+
+   Returns an array obtained by mapping the function ``fn`` over array
+   ``arr``. Each application of ``fn`` has an element of ``arr`` as
+   its first argument and the index of that element as its second
+   argument.
+
+   ``map`` and ``mapData`` differ in that the use of ``mapData``
+   asserts to the inference back end that all executions of ``fn`` are
+   conditionally independent. This information can potentially be
+   exploited on a per algorithm basis to improve the efficiency of
+   inference.
+
+   ``mapData`` also provides an interface through which inference
+   algorithms can support data sub-sampling. Where supported, the size
+   of a "mini-batch" can be specified using the ``batchSize`` option.
+   When using data sub-sampling the array normally returned by
+   ``mapData`` is not computed in its entirety, so ``undefined`` is
+   returned in its place.
+
+   Only the :ref:`ELBO <elbo>` optimization objective takes advantage
+   of ``mapData`` at this time.
+
+   ::
+
+      mapData({data: [0, 1, 2]}, function(x) { return x + 1; }); // => [1, 2, 3]
+      mapData({data: data, batchSize: 10}, fn);
+
 .. js:function:: map2(fn, arr1, arr2)
 
    Returns an array obtained by mapping the function ``fn`` over

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -104,6 +104,14 @@ The following estimators are available:
    This is the evidence lower bound (ELBO). Optimizing this objective
    yields variational inference.
 
+   For best performance use :js:func:`mapData` in place of
+   :js:func:`map` where possible when optimizing this objective. The
+   conditional independence information this provides is used to
+   reduce the variance of gradient estimates which can significantly
+   improve performance, particularly in the presence of discrete
+   random choices. Data sub-sampling is also supported through the use
+   of :js:func:`mapData`.
+
    The following options are supported:
 
    .. describe:: samples

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -118,21 +118,16 @@ module.exports = function(env) {
     return k(s, dims === dimsForScalarParam ? ad.tensor.get(val, 0) : val);
   };
 
-  // `mapData` maps a function over an array much like the `map`
-  // function. It differs in that the use of `mapData` signals to the
-  // language that the random choices in each `obsFn` are
-  // conditionally independent given the random choices made before
-  // `mapData`.
-
-  // It is the responsibility of individual coroutines to make use of
-  // this information in an appropriate way. To do so, coroutines can
-  // implement one or more of the following methods:
+  // It is the responsibility of individual coroutines to implement
+  // data sub-sampling and to make use of the conditional independence
+  // information mapData provides. To do so, coroutines can implement
+  // one or more of the following methods:
 
   // mapDataFetch: Called when mapData is entered, providing an
-  // opportunity to perform book-keeping etc. This method should
-  // return an array of indices indicating the data to be mapped over.
-  // Alternatively, null can be returned to indicate that all data
-  // should be used.
+  // opportunity to perform book-keeping etc. When sub-sampling data
+  // this method should return an array of indices indicating the data
+  // to be mapped over. Alternatively, null can be returned to
+  // indicate that all data should be used.
 
   // mapDataEnter/mapDataLeave: Called before/after every application
   // of the observation function.

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -158,12 +158,13 @@ module.exports = function(env) {
         null;
 
     assert.ok(ix === null || _.isArray(ix));
+    var doReturn = ix === null; // We return undefined when sub-sampling data.
 
     return cpsMapData(s, function(s, v) {
       if (env.coroutine.mapDataFinal) {
         env.coroutine.mapDataFinal(a);
       }
-      return k(s, v);
+      return k(s, doReturn ? v : undefined);
     }, a, data, ix, obsFn);
   }
 


### PR DESCRIPTION
This adds docs for `mapData` and changes the return value when sub-samping data as discussed in #662.

Closes #569.
Closes #662.