### PR TITLE
Preserve the computed property during transform.

### DIFF
--- a/src/transforms/ad.js
+++ b/src/transforms/ad.js
@@ -74,7 +74,7 @@ function ad(ast) {
       if (node.type === 'MemberExpression' &&
           node.object.type === 'Identifier' &&
           node.object.name === 'Math') {
-        return build.memberExpression(parse('ad.scalar'), node.property);
+        return build.memberExpression(parse('ad.scalar'), node.property, node.computed);
       }
     }
   });


### PR DESCRIPTION
Wihout this `Math[method]` will be transformed in to `ad.scalar.method` rather than `ad.scalar[method]`.