### PR TITLE
Minor optimization.

### DIFF
--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -167,7 +167,7 @@ module.exports = function(env) {
   }
 
   function allFinite(tensor) {
-    return _.all(tensor.data, _.isFinite);
+    return _.all(tensor.data, isFinite);
   }
 
   function checkGradients(gradObj) {


### PR DESCRIPTION
Writing it this way saves a little work.

This occasionally showed up in profiling and is probably worth changing since it's so simple, but in general these gradient checks appear to be very cheap compared to everything else we do.