### PR TITLE
Throw error when unable to generate guide.

### DIFF
--- a/src/guide.js
+++ b/src/guide.js
@@ -111,9 +111,19 @@ function spec(targetDist) {
     return betaSpec(targetDist);
   } else if (targetDist instanceof dists.Discrete) {
     return discreteSpec(targetDist);
+  } else if (targetDist instanceof dists.RandomInteger ||
+             targetDist instanceof dists.Binomial ||
+             targetDist instanceof dists.MultivariateGaussian) {
+    throwAutoGuideError(targetDist);
   } else {
     return defaultSpec(targetDist);
   }
+}
+
+function throwAutoGuideError(targetDist) {
+  var msg = 'Cannot automatically generate a guide for a ' +
+      targetDist.meta.name + ' distribution.';
+  throw new Error(msg);
 }
 
 // The default is a guide of the same type as the target. We determine
@@ -132,9 +142,7 @@ function defaultSpec(targetDist) {
     } else if (_.isNumber(targetParam)) {
       dims = [1];
     } else {
-      var msg = 'Cannot automatically generate a guide for a ' +
-          targetDist.meta.name + ' distribution.';
-      throw new Error(msg);
+      throwAutoGuideError(targetDist);
     }
 
     return [name, {param: {dims: dims, domain: paramMeta.domain}}];


### PR DESCRIPTION
Not all distributions can be guided automatically at present. This will eventually be addressed by #573. In the meantime, this change will catch these cases and show a useful error.