### PR TITLE
Improved interface for Infer and Optimize.

### DIFF
--- a/docs/inference/index.rst
+++ b/docs/inference/index.rst
@@ -10,20 +10,19 @@ the distribution on return values implicitly represented by a
 (In general, computing this distribution is intractable, so often the
 goal is to compute an approximation to it.)
 
-This is achieved WebPPL using the ``Infer(options, model)`` function
-which takes a function of zero arguments representing a stochastic
-computation, ``model``, and returns the distribution on return values
-represented as a :ref:`distribution object<distributions>`.
+This is achieved in WebPPL using the ``Infer`` function, which takes a
+function of zero arguments representing a stochastic computation and
+returns the distribution on return values represented as a
+:ref:`distribution object<distributions>`. For example::
 
-Several implementations of marginal inference are built into WebPPL.
-The ``method`` option is used to specify which implementation should
-be used. For example::
+   Infer({model: function() {
+       return flip() + flip();
+   });
 
-  Infer({method: 'enumerate'}, function() {
-    return flip() + flip();
-  });
-
-Information about the individual methods is available here:
+``Infer`` will perform inference using :ref:`enumeration<enumerate>`
+by default, but several other implementations of marginal inference
+are also built into WebPPL. Information about the individual methods
+is available here:
 
 .. toctree::
    :maxdepth: 2

--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -6,7 +6,7 @@ Methods
 Enumeration
 -----------
 
-.. js:function:: Infer({method: 'enumerate'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'enumerate'[, ...]})
 
    This method performs inference by enumeration.
 
@@ -28,13 +28,13 @@ Enumeration
 
    Example usage::
 
-     Infer({method: 'enumerate', maxExecutions: 10}, model);
-     Infer({method: 'enumerate', strategy: 'breadthFirst'}, model);
+     Infer({method: 'enumerate', maxExecutions: 10, model: model});
+     Infer({method: 'enumerate', strategy: 'breadthFirst', model: model});
 
 Rejection sampling
 ------------------
 
-.. js:function:: Infer({method: 'rejection'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'rejection'[, ...]})
 
    This method performs inference using rejection sampling.
 
@@ -65,12 +65,12 @@ Rejection sampling
 
    Example usage::
 
-     Infer({method: 'rejection', samples: 100}, model);
+     Infer({method: 'rejection', samples: 100, model: model});
 
 MCMC
 ----
 
-.. js:function:: Infer({method: 'MCMC'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'MCMC'[, ...]})
 
    This method performs inference using Markov chain Monte Carlo.
 
@@ -127,7 +127,7 @@ MCMC
 
    Example usage::
 
-     Infer({method: 'MCMC', samples: 1000, lag: 100, burn: 5}, model);
+     Infer({method: 'MCMC', samples: 1000, lag: 100, burn: 5, model: model});
 
 Kernels
 ^^^^^^^
@@ -143,7 +143,7 @@ The following kernels are available:
 
 Example usage::
 
-    Infer({method: 'MCMC', kernel: 'MH'}, model);
+    Infer({method: 'MCMC', kernel: 'MH', model: model});
 
 .. describe:: HMC
 
@@ -169,13 +169,13 @@ Example usage::
 
 Example usage::
 
-    Infer({method: 'MCMC', kernel: 'HMC'}, model);
-    Infer({method: 'MCMC', kernel: {HMC: {steps: 10, stepSize: 1}}}, model);
+    Infer({method: 'MCMC', kernel: 'HMC', model: model});
+    Infer({method: 'MCMC', kernel: {HMC: {steps: 10, stepSize: 1}}, model: model});
 
 Incremental MH
 --------------
 
-.. js:function:: Infer({method: 'incrementalMH'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'incrementalMH'[, ...]})
 
    This method performs inference using C3. [ritchie15]_
 
@@ -229,7 +229,7 @@ Incremental MH
 
    Example usage::
 
-     Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10}, model);
+     Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10, model: model});
 
    To maximize efficiency when inferring marginals over multiple variables, use the ``query`` table, rather than building up a list of variable values::
 
@@ -247,7 +247,7 @@ Incremental MH
         hmm(100, observed_data);
         return query;
       }
-      Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10}, model);
+      Infer({method: 'incrementalMH', samples: 100, lag: 5, burn: 10, model: model});
 
    ``query`` is a write-only table which can be returned from a program (and thus marginalized). The only operation it supports is adding named values:
 
@@ -261,7 +261,7 @@ Incremental MH
 SMC
 ---
 
-.. js:function:: Infer({method: 'SMC'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'SMC'[, ...]})
 
    This method performs inference using sequential Monte Carlo. When
    ``rejuvSteps`` is 0, this method is also known as a particle
@@ -291,7 +291,7 @@ SMC
 
    Example usage::
 
-     Infer({method: 'SMC', particles: 100, rejuvSteps: 5}, model);
+     Infer({method: 'SMC', particles: 100, rejuvSteps: 5, model: model});
 
    By default SMC uses the prior as the importance distribution. Other
    distributions can be used by specifying :ref:`guide distributions
@@ -303,7 +303,7 @@ SMC
 Optimization
 ------------
 
-.. js:function:: Infer({method: 'optimize'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'optimize'[, ...]})
 
    This method performs inference by :ref:`optimizing <optimization>`
    the parameters of the guide program. The marginal distribution is a
@@ -324,12 +324,12 @@ Optimization
 
    Example usage::
 
-     Infer({method: 'optimize', samples: 100, steps: 100}, model);
+     Infer({method: 'optimize', samples: 100, steps: 100, model: model});
 
 Forward Sampling
 ----------------
 
-.. js:function:: Infer({method: 'forward'[, ...]}, model)
+.. js:function:: Infer({model: ..., method: 'forward'[, ...]})
 
    This method builds a histogram of return values obtained by
    repeatedly executing either the target or :ref:`guide <guides>`
@@ -363,8 +363,8 @@ Forward Sampling
 
    Example usage::
 
-     Infer({method: 'forward'}, model);
-     Infer({method: 'forward', guide: true, params: optimizedParams}, model);
+     Infer({method: 'forward', model: model});
+     Infer({method: 'forward', guide: true, params: optimizedParams, model: model});
 
 .. rubric:: Bibliography
 

--- a/docs/optimization.rst
+++ b/docs/optimization.rst
@@ -35,15 +35,22 @@ optimization <optimize>`, primitives for specifying :ref:`parameters
 Optimize
 ~~~~~~~~
 
-.. js:function:: Optimize(model, options)
+.. js:function:: Optimize(options)
 
-   :param function model: Specifies the guide program.
    :param object options: Optimization options.
    :returns: Optimized parameters.
 
-   Optimizes the parameters of the guide program.
+   Optimizes the parameters of the guide program specified by the
+   ``model`` option.
 
    The following options are supported:
+
+   .. describe:: model
+
+      A function of zero arguments that specifies the target and guide
+      programs.
+
+      This option must be present.
 
    .. describe:: steps
 
@@ -87,10 +94,10 @@ Optimize
 
 Example usage::
 
-  var newParams = Optimize(model, {steps: 100});
-  var newParams = Optimize(model, {steps: 100, params: oldParams});
-  var newParams = Optimize(model, {optMethod: 'adagrad'});
-  var newParams = Optimize(model, {optMethod: {sgd: {stepSize: 0.5}}});
+  var newParams = Optimize({model: model, steps: 100});
+  var newParams = Optimize({model: model, steps: 100, params: oldParams});
+  var newParams = Optimize({model: model, optMethod: 'adagrad'});
+  var newParams = Optimize({model: model, optMethod: {sgd: {stepSize: 0.5}}});
 
 Estimators
 ++++++++++
@@ -136,8 +143,8 @@ The following estimators are available:
 
 Example usage::
 
-  Optimize(model, {estimator: 'ELBO'});
-  Optimize(model, {estimator: {ELBO: {samples: 10}}});
+  Optimize({model: model, estimator: 'ELBO'});
+  Optimize({model: model, estimator: {ELBO: {samples: 10}}});
 
 .. _parameters:
 

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -478,8 +478,8 @@ var Infer = function(options, maybeFn) {
   if (!util.isObject(options)) {
     util.fatal('Infer: expected first argument to be an options object.');
   }
-  var model = maybeFn || options.model;
-  if (!_.isFunction(model)) {
+  var wpplFn = maybeFn || options.model;
+  if (!_.isFunction(wpplFn)) {
     util.fatal('Infer: a model was not specified.');
   }
 
@@ -507,7 +507,7 @@ var Infer = function(options, maybeFn) {
     util.fatal(msg);
   }
   var method = methodMap[methodName];
-  return method(model, _.omit(options, 'method', 'model'));
+  return method(wpplFn, _.omit(options, 'method', 'model'));
 };
 
 // Convenience function for creating maximum likelihood model

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -474,12 +474,13 @@ var OptimizeThenSample = function(wpplFn, options) {
   return SampleGuide(wpplFn, opts);
 };
 
-var Infer = function(options, wpplFn) {
+var Infer = function(options, maybeFn) {
   if (!util.isObject(options)) {
     util.fatal('Infer: expected first argument to be an options object.');
   }
-  if (!_.isFunction(wpplFn)) {
-    util.fatal('Infer: expected second argument to be a function.');
+  var model = maybeFn || options.model;
+  if (!_.isFunction(model)) {
+    util.fatal('Infer: a model was not specified.');
   }
 
   // Map from camelCase options to PascalCase coroutine names. Also
@@ -497,10 +498,7 @@ var Infer = function(options, wpplFn) {
     optimize: OptimizeThenSample
   };
 
-  var methodName = options.method;
-  if (methodName === undefined) {
-    util.fatal('Infer: the \'method\' option must be specified.');
-  }
+  var methodName = options.method || 'enumerate';
   if (!_.has(methodMap, methodName)) {
     var methodNames = _.keys(methodMap);
     var msg = 'Infer: \'' + methodName +
@@ -509,7 +507,7 @@ var Infer = function(options, wpplFn) {
     util.fatal(msg);
   }
   var method = methodMap[methodName];
-  return method(wpplFn, _.omit(options, 'method'));
+  return method(model, _.omit(options, 'method', 'model'));
 };
 
 // Convenience function for creating maximum likelihood model

--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -26,7 +26,25 @@ module.exports = function(env) {
     EUBO: require('./eubo')(env)
   };
 
-  function Optimize(s, k, a, wpplFn, options) {
+  function Optimize(s, k, a, fnOrOptions, maybeOptions) {
+    var wpplFn, options;
+    if (_.isFunction(fnOrOptions)) {
+      wpplFn = fnOrOptions;
+      options = maybeOptions;
+    } else if (util.isObject(fnOrOptions)) {
+      wpplFn = fnOrOptions.model;
+      options = _.omit(fnOrOptions, 'model');
+      if (!_.isFunction(wpplFn) && _.isFunction(maybeOptions)) {
+        throw new Error('Optimize: expected model to be included in options.');
+      }
+    } else {
+      throw new Error('Optimize: expected first argument to be an options object or a function.');
+    }
+
+    if (!_.isFunction(wpplFn)) {
+      throw new Error('Optimize: a model was not specified.');
+    }
+
     options = util.mergeDefaults(options, {
       params: {},
       optMethod: 'adam',

--- a/tests/test-data/deterministic/expected/infer.json
+++ b/tests/test-data/deterministic/expected/infer.json
@@ -1,0 +1,3 @@
+{
+  "result": [true, true, true]
+}

--- a/tests/test-data/deterministic/models/infer.wppl
+++ b/tests/test-data/deterministic/models/infer.wppl
@@ -1,0 +1,9 @@
+var model = function() {
+  return flip(1);
+};
+[
+  // Test the use of ES6 object literal shorthand.
+  sample(Infer({model})),
+  sample(Infer({model: model})),
+  sample(Infer({model() { return model(); }}))
+];


### PR DESCRIPTION
This implements the interface for `Infer` suggested in #629, allowing us to specify a default inference method. I've also updated `Optimize` to work in much the same way.

Since ES6 style object literal shorthand already works in WebPPL, then this change allows us to write things like:

``` js
Infer({model() {
  return flip();
}});

Infer({method: 'rejection', model() {
  return flip();
}});

var model = function() {};
Infer({model});
Infer({model, method: 'rejection'});
```

I've update the docs to reflect this new interface. However, the old interface still works, so I don't expect this change to break anything.

Closes #629.
