### PR TITLE
Make error handling work for errors throw in deeply nested JS function calls.

### DIFF
--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -54,14 +54,18 @@ function filterJsStackTrace(stackTrace) {
   // taking the top-most entry corresponding to a function application
   // in webppl code, and any frames above it.
 
+  // When no entry corresponding to application of a webppl function
+  // is present, we return the entire stack. The reason this is
+  // possible is that (by default in V8) only the top 10 stack frames
+  // are captured on error.
+
   // We can only ever take the top-most webppl frame as any earlier
   // frames may have been generated on a different execution path.
   // (And besides, there should only be one entry as the JS stack is
   // cleared between each webppl function application.)
 
   var ix = _.findIndex(stackTrace, _.matcher({webppl: true}));
-  assert.ok(ix !== undefined, 'Expected to find wppl entry in JS stack trace.');
-  return stackTrace.slice(0, ix).concat(stackTrace[ix]);
+  return (ix >= 0) ? stackTrace.slice(0, ix).concat(stackTrace[ix]) : stackTrace;
 }
 
 function filterGensym(name) {

--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -65,7 +65,7 @@ function filterJsStackTrace(stackTrace) {
   // cleared between each webppl function application.)
 
   var ix = _.findIndex(stackTrace, _.matcher({webppl: true}));
-  return (ix >= 0) ? stackTrace.slice(0, ix).concat(stackTrace[ix]) : stackTrace;
+  return (ix >= 0) ? stackTrace.slice(0, ix + 1) : stackTrace;
 }
 
 function filterGensym(name) {

--- a/tests/test-stack-trace.js
+++ b/tests/test-stack-trace.js
@@ -117,6 +117,13 @@ var testDefs = [
     debug: true
   },
 
+  { name: 'no webppl entry in stack trace',
+    code: 'util.fatal(util.jsnew(Error))',
+    stack: [{file: RegExp(path.join('src', 'util.js') + '$'), webppl: false, name: null}],
+    debug: true,
+    limit: 1
+  },
+
   // The idea here is to test that the stack is as expected at the
   // error which occurs after we continue from the sample statement
   // for the second time.
@@ -166,18 +173,22 @@ function testEntry(entry, props, test) {
   }
 }
 
-function getStack(code, debug) {
-  var stack;
+function getStack(code, debug, limit) {
+  var stack, oldLimit;
   try {
+    oldLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = (limit !== undefined) ? limit : oldLimit;
     webppl.run(code, null, {debug: debug});
   } catch (e) {
     stack = errors.recoverStack(e, parseV8);
+  } finally {
+    Error.stackTraceLimit = oldLimit;
   }
   return stack;
 }
 
 function runTest(def, test) {
-  var stack = getStack(def.code, def.debug);
+  var stack = getStack(def.code, def.debug, def.limit);
   var expectedStack = def.stack;
   //console.log(JSON.stringify(stack));
   //console.log(JSON.stringify(expectedStack));


### PR DESCRIPTION
Closes #613.