### PR TITLE
Bump adnn to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "adnn": "^2.0.0",
+    "adnn": "^2.0.2",
     "amdefine": "^1.0.0",
     "ast-types": "^0.8.13",
     "colors": "^1.1.2",


### PR DESCRIPTION
adnn 2.0.1 introduces some optimizations and 2.0.2 solves a problem with running the browserified package inside non-browser environments -- can we upgrade the dependency to 2.0.2?