### PR TITLE
Fix value reported in EUBO output.

### DIFF
--- a/src/inference/eubo.ad.js
+++ b/src/inference/eubo.ad.js
@@ -103,7 +103,9 @@ module.exports = function(env) {
           return params.map(ad.derivative);
         });
 
-        return cont(grads, -ad.value(objective));
+        var logp = ad.value(trace.score);
+        var logq = ad.value(this.logq);
+        return cont(grads, logp - logq);
 
       }.bind(this), this.a);
 


### PR DESCRIPTION
This fixes a bug which meant the output from the EUBO estimator showed the value of `-log q` rather than the value of the thing we are optimizing.