### PR TITLE
Add 'justSample' and 'onlyMAP' to SMC

### DIFF
--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -289,6 +289,22 @@ SMC
 
          Default: ``'MH'``
 
+      .. describe:: justSample
+
+         When ``true``, maintain an array of all samples taken. This
+         is available via the ``samples`` property of the returned
+         marginal distribution. ``justSample`` implies ``onlyMAP``.
+
+         Default: ``false``
+
+      .. describe:: onlyMAP
+
+         When ``true``, return a delta distribution on the sampled
+         value with the highest score instead of a marginal
+         distribution built from all samples.
+
+         Default: ``false``
+
    Example usage::
 
      Infer({method: 'SMC', particles: 100, rejuvSteps: 5, model: model});

--- a/src/aggregation/MaxAggregator.js
+++ b/src/aggregation/MaxAggregator.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var util = require('../util');
 var ad = require('../ad');
-var CountAggregator = require('../aggregation/CountAggregator');
+var dists = require('../dists');
 
 var MaxAggregator = function(retainSamples) {
   this.max = { value: undefined, score: -Infinity };
@@ -22,9 +22,7 @@ MaxAggregator.prototype.add = function(value, score) {
 };
 
 MaxAggregator.prototype.toDist = function() {
-  var hist = new CountAggregator();
-  hist.add(this.max.value);
-  var dist = hist.toDist();
+  var dist = new dists.MAP({ val: this.max.value });
   if (this.retainSamples) {
     dist.samples = this.samples;
   }

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -1354,6 +1354,28 @@ var Marginal = makeDistributionType({
   }
 });
 
+// Distribution type used by MaxAggregator
+var MAP = makeDistributionType({
+  name: 'MAP',
+  nodoc: true,
+  nohelper: true,
+  params: [{name: 'val'}],
+  mixins: [finiteSupport],
+  constructor: function() {},
+  sample: function() {
+    return this.params.val;
+  },
+  score: function(val) {
+    throw new Error('MAP distribution objects cannot compute scores');
+  },
+  support: function() {
+    return [this.params.val];
+  },
+  print: function() {
+    return 'MAP value: ' + this.params.val;
+  }
+});
+
 
 var Categorical = makeDistributionType({
   name: 'Categorical',
@@ -1440,6 +1462,7 @@ var distributions = {
   Poisson: Poisson,
   Dirichlet: Dirichlet,
   Marginal: Marginal,
+  MAP: MAP,
   Categorical: Categorical,
   Delta: Delta
 };


### PR DESCRIPTION
This also stops MaxAggregator from returning a histogram-based distribution object (it instead uses a new 'MAP' distribution type).

This is necessary because the call to to `util.serialize` in `CountAggregator.toDist' can take *forever* for non-trivial objects (as in, multiple minutes, and then it sometimes crashes trying to allocate a string larger than what JSON.stringify can handle). I've hacked around this for graphics demos in the past, but I got fed up with it this time around and decided to actually fix it in core webppl.