### PR TITLE
Fix bug recovering stack.

### DIFF
--- a/src/errors/errors.js
+++ b/src/errors/errors.js
@@ -78,29 +78,31 @@ function sourceMapJsStackTrace(stackTrace, sourceMap) {
 
   var map = new SourceMap.SourceMapConsumer(sourceMap);
 
-  return stackTrace.map(function(entry) {
+  return _.chain(stackTrace).map(function(entry) {
     if (entry.webppl) {
       var pos = map.originalPositionFor({
         line: entry.lineNumber,
         column: entry.columnNumber
       });
 
-      assert.ok(pos.line !== null);
-      assert.ok(pos.column !== null);
-      assert.ok(pos.source !== null);
-
-      return {
-        fileName: pos.source,
-        lineNumber: pos.line,
-        columnNumber: pos.column,
-        native: entry.native,
-        webppl: true,
-        name: filterGensym(pos.name)
-      };
+      return positionPopulated(pos) ?
+          {
+            fileName: pos.source,
+            lineNumber: pos.line,
+            columnNumber: pos.column,
+            native: entry.native,
+            webppl: true,
+            name: filterGensym(pos.name)
+          } :
+          null;
     } else {
       return entry;
     }
-  });
+  }).filter().value();
+}
+
+function positionPopulated(pos) {
+  return pos.source !== null && pos.line !== null && pos.column !== null;
 }
 
 module.exports = {

--- a/tests/test-stack-trace.js
+++ b/tests/test-stack-trace.js
@@ -137,10 +137,14 @@ var testDefs = [
   },
 
   { name: 'top most webppl entry is not a user function',
-    code: ['var f = function() { stackTraceTestFns.test() };',
+    code: ['var testFn = stackTraceTestFns.test;',
+           'var f = function() { return testFn(); };',
            'f();'
     ].join('\n'),
-    stack: [{webppl: true, line: 2, col: 0, name: 'f'}],
+    stack: [
+      {file: RegExp('test-stack-trace.js$'), webppl: false, line: 16, col: 12},
+      {webppl: false}, {webppl: false}, {webppl: false}, // Uninteresting entries from runner.
+      {webppl: true, line: 3, col: 0, name: 'f'}],
     debug: true
   },
 

--- a/tests/test-stack-trace.js
+++ b/tests/test-stack-trace.js
@@ -6,6 +6,18 @@ var webppl = require('../src/main');
 var errors = require('../src/errors/errors');
 var parseV8 = require('../src/errors/parsers').parseV8;
 
+var stackTraceTestFns = {
+  test: function(s, k, a) {
+    // This simulates an exception in back-end code been throw after
+    // the stack has been cleared. In this setting there is no entry
+    // on the JS stack corresponding to a webppl call made from user
+    // code.
+    return function() {
+      throw new Error();
+    };
+  }
+};
+
 var testDefs = [
   { name: 'top-level',
     code: 'null[0]',
@@ -124,6 +136,14 @@ var testDefs = [
     limit: 1
   },
 
+  { name: 'top most webppl entry is not a user function',
+    code: ['var f = function() { stackTraceTestFns.test() };',
+           'f();'
+    ].join('\n'),
+    stack: [{webppl: true, line: 2, col: 0, name: 'f'}],
+    debug: true
+  },
+
   // The idea here is to test that the stack is as expected at the
   // error which occurs after we continue from the sample statement
   // for the second time.
@@ -178,10 +198,12 @@ function getStack(code, debug, limit) {
   try {
     oldLimit = Error.stackTraceLimit;
     Error.stackTraceLimit = (limit !== undefined) ? limit : oldLimit;
+    global.stackTraceTestFns = stackTraceTestFns;
     webppl.run(code, null, {debug: debug});
   } catch (e) {
     stack = errors.recoverStack(e, parseV8);
   } finally {
+    delete global.stackTraceTestFns;
     Error.stackTraceLimit = oldLimit;
   }
   return stack;


### PR DESCRIPTION
This fixes a bug that I ran into when working on #715. Without this, the error message shown when a guide thunk doesn't return a distribution object doesn't include the most recent position in user code.