### PR TITLE
Push remaining printing logic into dist objects.

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -52,7 +52,11 @@ Distribution.prototype = {
 
   inspect: function(depth, options) {
     if (_.has(this, 'params')) {
-      return [this.meta.name, '(', inspect(this.params), ')'].join('');
+      if (this.print) {
+        return this.print();
+      } else {
+        return [this.meta.name, '(', inspect(this.params), ')'].join('');
+      }
     } else {
       // This isn't an instance of a distribution type.
       // e.g. Uniform.prototype.inspect()
@@ -1351,7 +1355,7 @@ var Marginal = makeDistributionType({
     return this.supp;
   },
   print: function() {
-    return printDist(this.params.dist);
+    return printMarginal(this.params.dist);
   }
 });
 
@@ -1419,12 +1423,12 @@ var SampleBasedMarginal = makeDistributionType({
     }
   },
   print: function() {
-    return printDist(this.getDist());
+    return printMarginal(this.getDist());
   }
 });
 
-function printDist(dist) {
-  return _.map(dist, function(obj, val) { return [val, obj.prob]; })
+function printMarginal(dist) {
+  return 'Marginal:\n' + _.map(dist, function(obj, val) { return [val, obj.prob]; })
     .sort(function(a, b) { return b[1] - a[1]; })
     .map(function(pair) { return '    ' + pair[0] + ' : ' + pair[1]; })
     .join('\n');

--- a/webppl
+++ b/webppl
@@ -8,7 +8,6 @@ var pkg = require('./src/pkg');
 var util = require('./src/util');
 var pkginfo = require('./src/pkginfo');
 var git = require('./src/git');
-var dists = require('./src/dists');
 var errors = require('./src/errors/errors');
 var parseV8 = require('./src/errors/parsers').parseV8;
 var showError = require('./src/errors/node').showError;
@@ -16,12 +15,7 @@ var parseArgs = require('minimist');
 var _ = require('underscore');
 
 function printWebPPLValue(x) {
-  if (dists.isDist(x) && x.print) {
-    console.log(x.meta.name + ':');
-    console.log(x.print());
-  } else {
-    console.log(x);
-  }
+  console.log(x);
 };
 
 function topK(s, x) {

--- a/webppl
+++ b/webppl
@@ -14,12 +14,8 @@ var showError = require('./src/errors/node').showError;
 var parseArgs = require('minimist');
 var _ = require('underscore');
 
-function printWebPPLValue(x) {
-  console.log(x);
-};
-
 function topK(s, x) {
-  printWebPPLValue(x);
+  console.log(x);
 };
 
 function run(code, packages, verbose, debug, programFile) {
@@ -76,7 +72,6 @@ function compile(code, packages, verbose, debug, programFile, outputFile) {
 
   compiledCode += lines([
     'var __runner__ = util.trampolineRunners.cli();',
-    printWebPPLValue.toString() + ';',
     topK.toString() + ';',
     'var main = ' + compiledBody + '\n',
     "main({})(__runner__)({}, topK, '');"


### PR DESCRIPTION
This is a minor change to the way marginals are printed under node. It removes the last remaining bit of special casing for marginal dists, from the code that prints the value of the last expression in a program. The upshot is that `var m = Infer({...}); display(m)` now prints the same thing as just doing `var m = Infer({...}); m`. Previously, the former printed the internal data structures backing the marginal, rather than the pretty output generated by the latter.

Closes #698.