### PR TITLE
Fix name of sample based marginal dist type

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -1359,7 +1359,7 @@ var Marginal = makeDistributionType({
 // A "list of samples" backed marginal distribution that only
 // aggregates the samples into a distribution when necessary.
 var SampleBasedMarginal = makeDistributionType({
-  name: 'Marginal',
+  name: 'SampleBasedMarginal',
   nodoc: true,
   nohelper: true,
   params: [{name: 'samples'}],


### PR DESCRIPTION
Not doing as part of #712 was a mistake by me. By itself this change leads to undesirable printing of this marginal (it includes the name "SampleBasedMarginal"), but happily that's fixed by #718.