### PR TITLE
Add `extend` to header

### DIFF
--- a/docs/functions/header.rst
+++ b/docs/functions/header.rst
@@ -29,6 +29,19 @@ Header
       var pair = function(x, y) { return [x, y]; };
       mapObject(pair, {a: 1, b: 2}); // => {a: ['a', 1], b: ['b', 2]}
 
+.. js:function:: extend(obj1, obj2, ...)
+
+   Creates a new object and assigns own enumerable string-keyed properties
+   of source objects 1, 2, ... to it. Source objects are applied from left
+   to right. Subsequent sources overwrite property assignments of previous
+   sources.
+
+   ::
+
+      var x = { a: 1, b: 2 };
+      var y = { b: 3, c: 4 };
+      extend(x, y);  // => { a: 1, b: 3, c: 4 }
+
 .. js:function:: mem(fn)
 
    Returns a memoized version of ``fn``. The memoized function is

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -232,7 +232,7 @@ var mapObject = function(fn, obj) {
 };
 
 var extend = function() {
-  return _.extend.apply(_, [{}].concat(arguments));
+  return _.extendOwn.apply(_, [{}].concat(arguments));
 }
 
 var reduce = function(fn, init, ar) {

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -394,6 +394,14 @@ var repeat = function(n, fn) {
   return helper(n);
 }
 
+var range = function(n) {
+  if (n === 0) {
+    return [];
+  } else {
+    return range(n - 1).concat([n - 1]);
+  }
+};
+
 var compose = function(f, g) {
   return function(x) {
     return f(g(x));

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -231,9 +231,9 @@ var mapObject = function(fn, obj) {
   );
 };
 
-var extend = function(base, ext) {
-  return _.extend({}, base, ext);
-};
+var extend = function() {
+  return _.extend.apply(_, [{}].concat(arguments));
+}
 
 var reduce = function(fn, init, ar) {
   var n = ar.length;

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -398,14 +398,6 @@ var repeat = function(n, fn) {
   return helper(n);
 }
 
-var range = function(n) {
-  if (n === 0) {
-    return [];
-  } else {
-    return range(n - 1).concat([n - 1]);
-  }
-};
-
 var compose = function(f, g) {
   return function(x) {
     return f(g(x));

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -231,6 +231,10 @@ var mapObject = function(fn, obj) {
   );
 };
 
+var extend = function(base, ext) {
+  return _.extend({}, base, ext);
+};
+
 var reduce = function(fn, init, ar) {
   var n = ar.length;
   var helper = function(i) {

--- a/tests/test-data/deterministic/expected/extend.json
+++ b/tests/test-data/deterministic/expected/extend.json
@@ -1,0 +1,3 @@
+{
+  "result": [1, 2, null, null, null, 3, 4, null, 1, 3, 4, 5]
+}

--- a/tests/test-data/deterministic/models/extend.wppl
+++ b/tests/test-data/deterministic/models/extend.wppl
@@ -1,0 +1,5 @@
+var x = { a: 1, b: 2 };
+var y = { b: 3, c: 4 };
+var z = { d: 5 };
+var w = extend(x, y, z);
+[x.a, x.b, x.c || null, x.d || null, y.a || null, y.b, y.c, y.d || null, w.a, w.b, w.c, w.d];


### PR DESCRIPTION
We use this extremely commonly as part of AgentModels (more than 50 times, currently named `update`).