### PR TITLE
Sync. params after setting ID from program code.

### DIFF
--- a/src/params/header.js
+++ b/src/params/header.js
@@ -18,11 +18,17 @@ function setParams(s, k, a, prms) {
 }
 
 function setParamsId(s, k, a, id) {
-  return k(s, config.setId(id));
+  config.setId(id);
+  return params.sync(function() {
+    return k(s, id);
+  });
 }
 
 function setFreshParamsId(s, k, a) {
-  return k(s, config.setFreshId());
+  var id = config.setFreshId();
+  return params.sync(function() {
+    return k(s, id);
+  });
 }
 
 function getParamsId(s, k, a, id) {


### PR DESCRIPTION
This ensures that `getParams()` returns `{}` after calling `setFreshParamsId()`. (Or more generally, that the correct parameter set is available locally immediately after updating the parameter id.)