### PR TITLE
Make error handling work when resuming trampoline.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,9 @@ function prepare(codeAndAssets, k, options) {
   var currentAddress = {value: undefined};
   var defaultHandler = function(error) {
     errors.extendError(error, codeAndAssets, currentAddress);
+    // Trigger clean-up. When using the mongo store, the process won't
+    // exit until the connection is closed.
+    cleanup(_.identity);
     throw error;
   };
   var allErrorHandlers = [defaultHandler].concat(options.errorHandlers);
@@ -232,8 +235,9 @@ function prepare(codeAndAssets, k, options) {
 
   // Before the program finishes, we tell the param store to finish up
   // gracefully (e.g., shutting down a connection to a remote store).
+  var cleanup = params.stop;
   var finish = function(s, x) {
-    return params.stop(function() {
+    return cleanup(function() {
       return k(s, x);
     });
   };

--- a/webppl
+++ b/webppl
@@ -25,28 +25,29 @@ function run(code, packages, verbose, debug, programFile) {
     pkg.headers.forEach(webppl.requireHeader);
   });
 
-  try {
-    webppl.run(code, topK, {
-      bundles: webppl.parsePackageCode(packages, verbose),
-      filename: programFile,
-      verbose: verbose,
-      debug: debug
-    });
-  } catch (error) {
-    if (error instanceof Error && error.wpplRuntimeError) {
-      try {
-        var stack = errors.recoverStack(error, parseV8);
-        showError(error, stack, programFile, debug);
-        process.exitCode = 1;
-      } catch (e) {
-        // If we fail to generate a readable error message re-throw
-        // the original error.
-        throw error;
+  webppl.run(code, topK, {
+    bundles: webppl.parsePackageCode(packages, verbose),
+    filename: programFile,
+    verbose: verbose,
+    debug: debug,
+    errorHandlers: [
+      function(error) {
+        if (error instanceof Error && error.wpplRuntimeError) {
+          try {
+            var stack = errors.recoverStack(error, parseV8);
+            showError(error, stack, programFile, debug);
+            process.exitCode = 1;
+          } catch (e) {
+            // If we fail to generate a readable error message re-throw
+            // the original error.
+            throw error;
+          }
+        } else {
+          throw error;
+        }
       }
-    } else {
-      throw error;
-    }
-  }
+    ]
+  });
 }
 
 var lines = function(ar) {


### PR DESCRIPTION
At present, the use of the mongo parameter store breaks readable error messages under node.

For example, this program:

```js
assert.ok(false, 'fail')
```

results in this when using the memory store:

```
AssertionError: fail
    at test.wppl:1

1| assert.ok(false, 'fail');
   -------^
2| 
```

but with mongo we get:

```
/usr/local/lib/node_modules/mongodb/lib/utils.js:98
    process.nextTick(function() { throw err; });
                                  ^
AssertionError: fail
    at eval (eval at <anonymous> (/path/to/webppl/src/main.js:248:25), <anonymous>:14:44)
```

The problem is that calling async JS causes us to exit the [`try/catch`](https://github.com/probmods/webppl/blob/f3ca01301b2652c536ffbc9d0a44599188ea76e9/webppl#L28) that the webppl script wraps around the call to `webppl.run`. The fix is to supply the error handling logic via `webppl.run`'s `errorHandlers` argument, which was implemented to solve just this problem in the browser. (In the browser this comes up when the runner runs the continuation via `setTimeout`.)