### PR TITLE
Support reflection for static analysis

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -189,7 +189,10 @@ function compile(code, options) {
     ])(asts);
   };
 
-  return util.timeif(options.verbose, 'compile', _compile);
+  var r = util.timeif(options.verbose, 'compile', _compile);
+  global.__sourceMap__ = r.sourceMap;
+  global.__compiled__ = r.code;
+  return r;
 }
 
 function wrapWithHandler(f, handler) {
@@ -261,6 +264,10 @@ function prepare(codeAndAssets, k, options) {
 function run(code, k, options) {
   options = options || {};
   var codeAndAssets = compile(code, options);
+  global.__compiled__ = codeAndAssets.code;
+  if (_.has(codeAndAssets, 'sourceMap')) {
+    global.__sourceMap__ = codeAndAssets.sourceMap;
+  }
   util.timeif(options.verbose, 'run', prepare(codeAndAssets, k, options).run);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -190,6 +190,7 @@ function compile(code, options) {
   };
 
   var r = util.timeif(options.verbose, 'compile', _compile);
+  // provide compiled code and sourceMap to support reflection
   global.__sourceMap__ = r.sourceMap;
   global.__compiled__ = r.code;
   return r;
@@ -264,6 +265,7 @@ function prepare(codeAndAssets, k, options) {
 function run(code, k, options) {
   options = options || {};
   var codeAndAssets = compile(code, options);
+  // provide compiled code and sourceMap to support reflection
   global.__compiled__ = codeAndAssets.code;
   if (_.has(codeAndAssets, 'sourceMap')) {
     global.__sourceMap__ = codeAndAssets.sourceMap;


### PR DESCRIPTION
I'm starting to work on static analysis tools for webppl (e.g., `viz.model` for visualizing dependency diagrams of generative models, making `viz.auto` smarter wrt the actual supports of a distribution) and it's *far* easier to do this if I have access to both the original code, compiled code, and source map at run-time.

Example: `viz.model` ingests a function `f`, analyzes its source code via `f.toString()`, and visualizes the result. Except `f.toString()` is pretty hard to work with, as it has gone through a bunch of transforms. But.. it turns out that I can back out what `f`'s original source code was if I have access to the source map et al. This PR installs that information as global variables.

FWIW, I have hunch about a much cleaner way of supporting this sort of static analysis but I think it would be much more invasive, so this PR seems like a decent approach for the time being. (The idea: I think we can get away with doing code transforms at inference-time rather than compile-time if we change the signatures from `(s, k, a, x, ...)` to `(x, ..., s, k, a)`, so that any header functions would work both in JS and webppl)