### PR TITLE
Fix warnings in the browser

### DIFF
--- a/src/guide.js
+++ b/src/guide.js
@@ -95,14 +95,9 @@ function runIfThunkElseAuto(maybeThunk, targetDist, env, s, a, k) {
 // independent guide distributions and optimizing the elbo yields
 // mean-field variational inference.
 
-var autoGuideWarningIssued = false;
-
 function independent(targetDist, sampleAddress, env) {
 
-  if (!autoGuideWarningIssued) {
-    autoGuideWarningIssued = true;
-    util.warn('Automatically generating guide for one or more choices.');
-  }
+  util.warn('Automatically generating guide for one or more choices.', true);
 
   // Include the distribution name in the guide parameter name to
   // avoid collisions when the distribution type changes between

--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -203,14 +203,8 @@ module.exports = function(env) {
     });
   }
 
-  var issuedGradWarning = {};
-
   function logGradWarning(name, i, problem) {
-    var key = name + i + problem;
-    if (!_.has(issuedGradWarning, key)) {
-      console.warn('Gradient for param ' + name + ':' + i + ' is ' + problem + '.');
-      issuedGradWarning[key] = true;
-    }
+    util.warn('Gradient for param ' + name + ':' + i + ' is ' + problem + '.', true);
   }
 
   return {

--- a/src/main.js
+++ b/src/main.js
@@ -253,6 +253,7 @@ function prepare(codeAndAssets, k, options) {
       var initialAddress = '';
       return wpplFn(options.initialStore, finish, initialAddress);
     });
+    util.resetWarnings();
   };
 
   return { run: run };

--- a/src/params/header.js
+++ b/src/params/header.js
@@ -39,7 +39,6 @@ function getParamsId(s, k, a, id) {
 module.exports = function(env) {
 
   var dimsForScalarParam = [1];
-  var paramWarningIssued = false;
 
   // param provides a convenient wrapper around the primitive
   // params.register.
@@ -50,9 +49,8 @@ module.exports = function(env) {
       dims: dimsForScalarParam
     });
 
-    if (!env.coroutine._guide && !paramWarningIssued) {
-      paramWarningIssued = true;
-      util.warn('Warning: Parameter created outside of the guide.');
+    if (!env.coroutine._guide) {
+      util.warn('Warning: Parameter created outside of the guide.', true);
     }
 
     var mu = options.mu;

--- a/src/util.js
+++ b/src/util.js
@@ -270,9 +270,19 @@ function timeif(bool, name, thunk) {
   return bool ? time(name, thunk) : thunk();
 }
 
-function warn(msg) {
-  if (!global.suppressWarnings) {
-    console.warn(msg)
+var warningsIssued = {};
+
+function resetWarnings() {
+  warningsIssued = {};
+}
+
+function warn(msg, onceOnly) {
+  if (!global.suppressWarnings &&
+      (!onceOnly || !_.has(warningsIssued, msg))) {
+    console.warn(msg);
+    if (onceOnly) {
+      warningsIssued[msg] = true;
+    }
   }
 }
 
@@ -368,6 +378,7 @@ module.exports = {
   deserialize: deserialize,
   timeif: timeif,
   warn: warn,
+  resetWarnings: resetWarnings,
   fatal: fatal,
   jsnew: jsnew,
   isInteger: isInteger,

--- a/tests/test-inference.js
+++ b/tests/test-inference.js
@@ -703,11 +703,15 @@ var generateTestCases = function(seed) {
       exports[testDef.name][modelName] = _.partial(performTest, modelName, testDef);
     });
   });
+  var oldSuppressWarnings;
   exports.setUp = function(callback) {
+    oldSuppressWarnings = global.suppressWarnings;
+    global.suppressWarnings = true;
     util.seedRNG(seed);
     callback();
   };
   exports.tearDown = function(callback) {
+    global.suppressWarnings = oldSuppressWarnings;
     util.resetRNG();
     callback();
   };


### PR DESCRIPTION
The flags which track whether warnings have been issued while running a program persist across program executions in the browser. This results in a warning only been showing for the first program that encounters the warned about issue. (Oops, my mistake!)

The fix, implemented by this PR, is to move all of these flags to a central location, and reset them before a program is executed.