### PR TITLE
Improve `params.register()`

### DIFF
--- a/src/params/params.js
+++ b/src/params/params.js
@@ -73,10 +73,7 @@ function set(params, k) {
 }
 
 
-function register(env, name, getParams) {
-
-  // getParams is expected to be a function which is used to
-  // initialize parameters the first time they are encountered.
+function register(env, name, initParams) {
 
   var paramTable = get();
   var paramsSeen = env.coroutine.paramsSeen;
@@ -98,9 +95,9 @@ function register(env, name, getParams) {
       _params = paramTable[name];
     } else {
       // Never seen. Fetch initial values and add to store.
-      _params = getParams();
+      _params = initParams();
       assert.ok(_.every(_params, _.negate(ad.isLifted)),
-                'getParams unexpectedly returned a lifted value.');
+                'initParams unexpectedly returned a lifted value.');
       paramTable[name] = _params;
     }
 

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -112,13 +112,14 @@ function register(env, name, getParams) {
       paramTable[name] = _params;
     }
 
-    var params = _params.map(ad.lift);
-
     if (paramsSeen) {
+      var params = _params.map(ad.lift);
       paramsSeen[name] = params;
+      return params;
+    } else {
+      return _params;
     }
 
-    return params;
   }
 
 }

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var assert = require('assert');
 var _ = require('lodash');
 var fs = require('fs');
 var ad = require('../ad');
@@ -104,7 +105,10 @@ function register(env, name, getParams) {
       params = paramTable[name].map(ad.lift);
     } else {
       // Never seen. Fetch initial values, add to store and lift.
-      var prms = getParams().map(ad.value);
+      var prms = getParams();
+      assert.ok(_.every(prms, _.negate(ad.isLifted)),
+                'getParams unexpectedly returned a lifted value.');
+
       paramTable[name] = prms;
       params = prms.map(ad.lift);
     }

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -72,7 +72,7 @@ function set(params, k) {
 }
 
 
-function register(env, name, getParams, setParams) {
+function register(env, name, getParams) {
 
   // getParams is expected to be a function which is used to
   // initialize parameters the first time they are encoutered. At
@@ -111,11 +111,6 @@ function register(env, name, getParams, setParams) {
 
     if (paramsSeen) {
       paramsSeen[name] = params;
-    }
-
-    // Callback with the fresh ad graph nodes.
-    if (setParams) {
-      setParams(params);
     }
 
     return params;

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -98,20 +98,21 @@ function register(env, name, getParams) {
     // This is the first time we've encounter these params during
     // this execution. we will lift params at this point.
 
-    var params;
+    var _params;
 
     if (_.has(paramTable, name)) {
       // Seen on previous execution. Fetch from store and lift.
-      params = paramTable[name].map(ad.lift);
+      _params = paramTable[name];
     } else {
       // Never seen. Fetch initial values, add to store and lift.
-      var _params = getParams();
+      _params = getParams();
       assert.ok(_.every(_params, _.negate(ad.isLifted)),
                 'getParams unexpectedly returned a lifted value.');
 
       paramTable[name] = _params;
-      params = _params.map(ad.lift);
     }
+
+    var params = _params.map(ad.lift);
 
     if (paramsSeen) {
       paramsSeen[name] = params;

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -105,12 +105,12 @@ function register(env, name, getParams) {
       params = paramTable[name].map(ad.lift);
     } else {
       // Never seen. Fetch initial values, add to store and lift.
-      var prms = getParams();
-      assert.ok(_.every(prms, _.negate(ad.isLifted)),
+      var _params = getParams();
+      assert.ok(_.every(_params, _.negate(ad.isLifted)),
                 'getParams unexpectedly returned a lifted value.');
 
-      paramTable[name] = prms;
-      params = prms.map(ad.lift);
+      paramTable[name] = _params;
+      params = _params.map(ad.lift);
     }
 
     if (paramsSeen) {


### PR DESCRIPTION
This PR makes a few changes to the `params.register` method:

1. The `setParams` callback has been removed.
2. The function passed as the `getParams` argument is now expected to return unlifted parameters.
3. Parameters are only lifted when the current coroutine is performing optimization.
4. Improve comments.

Changes 1 & 2 don't affect core webppl, but they will break the implementation of `nnEval` in webppl-daipp. This will be addressed with an immediate follow-up PR that adds `nnEval` to webppl. (#663.)

Change 3 closes #634.

These changes are spread across a number of commits, which hopefully makes it easier to see that these are the only changes made. This could be squished down at merge if you like.