### PR TITLE
Docs: Tweak some headings.

### DIFF
--- a/docs/functions/index.rst
+++ b/docs/functions/index.rst
@@ -1,9 +1,9 @@
-Functions
-=========
+Built-in Functions
+==================
 
 .. toctree::
    :maxdepth: 2
 
    arrays
    tensors
-   header
+   other

--- a/docs/functions/other.rst
+++ b/docs/functions/other.rst
@@ -1,5 +1,5 @@
-Header
-======
+Other
+=====
 
 .. js:function:: display(val)
 


### PR DESCRIPTION
Some minor doc tweaks:

Rename "Functions" to "Built-in functions" to remove some ambiguity. (This section isn't about *defining* functions, for example.)

Also, rename "Header" to "Other". The former probably doesn't mean much to some users, and besides, most of the functions under "Array" and "Tensor" are also defined the header, so it's not particularly accurate.