### PR TITLE
Make EUBO work with guide thunks and auto guides.

### DIFF
--- a/src/inference/eubo.ad.js
+++ b/src/inference/eubo.ad.js
@@ -19,6 +19,7 @@ var assert = require('assert');
 var util = require('../util');
 var ad = require('../ad');
 var paramStruct = require('../params/struct');
+var guide = require('../guide');
 
 module.exports = function(env) {
 
@@ -113,25 +114,23 @@ module.exports = function(env) {
 
     sample: function(s, k, a, dist, options) {
       'use ad';
+      options = options || {};
+      return guide.getDistOrAuto(options.guide, dist, env, s, a, function(s, guideDist) {
+        var rel = util.relativizeAddress(env, a);
+        var guideVal = this.trace.findChoice(this.trace.baseAddress + rel).val;
+        assert.notStrictEqual(guideVal, undefined);
 
-      if (!_.has(options, 'guide')) {
-        throw 'Guide not specified.';
-      }
+        // We unlift guideVal to maintain the separation between the
+        // ad graph we're building in order to optimize the parameters
+        // and any ad graphs associated with the example traces. (The
+        // choices in an example trace can be ad nodes when they are
+        // generated with SMC + HMC rejuv.)
+        var _guideVal = ad.value(guideVal);
 
-      var guideDist = options.guide;
-      var rel = util.relativizeAddress(env, a);
-      var guideVal = this.trace.findChoice(this.trace.baseAddress + rel).val;
-      assert.notStrictEqual(guideVal, undefined);
+        this.logq += guideDist.score(_guideVal);
+        return k(s, _guideVal);
 
-      // We unlift guideVal to maintain the separation between the ad
-      // graph we're building in order to optimize the parameters and
-      // any ad graphs associated with the example traces. (The
-      // choices in an example trace can be ad nodes when they are
-      // generated with SMC + HMC rejuv.)
-      var _guideVal = ad.value(guideVal);
-
-      this.logq += guideDist.score(_guideVal);
-      return k(s, _guideVal);
+      }.bind(this));
     },
 
     factor: function(s, k, a, score) {

--- a/tests/test-data/deterministic/expected/eubo.json
+++ b/tests/test-data/deterministic/expected/eubo.json
@@ -1,0 +1,3 @@
+{
+  "result": [true, true]
+}

--- a/tests/test-data/deterministic/models/eubo.wppl
+++ b/tests/test-data/deterministic/models/eubo.wppl
@@ -1,0 +1,38 @@
+var optimize = function(model) {
+  var traces = Infer({
+    model,
+    method: 'SMC',
+    particles: 10,
+    importance: 'ignoreGuide',
+    saveTraces: true
+  }).traces;
+  Optimize({
+    model,
+    estimator: {EUBO: {traces}},
+    steps: 10,
+    verbose: false
+  });
+};
+
+// These serve as sanity checks so we at least know that EUBO runs
+// (without throwing an exception) on this simple model. At the time
+// of writing, we don't have a way to write inference tests for EUBO.
+
+[
+  (function() {
+    var model = function() {
+      return sample(Bernoulli({p: 0.9}), {guide() {
+        return Bernoulli({p: Math.sigmoid(param())});
+      }});
+    };
+    optimize(model);
+    return true;
+  })(),
+  (function() {
+    var model = function() {
+      return flip(0.9);
+    };
+    optimize(model);
+    return true;
+  })()
+];


### PR DESCRIPTION
The important part of this change is the use of `guide.getDistOrAuto` to get hold of the guide distribution. This takes care of running the guide thunk if present, or generate the mean field guide otherwise.

Closes #703.
Closes #746.