### PR TITLE
Rename global variable used to store runner.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -231,7 +231,7 @@ function prepare(codeAndAssets, k, options) {
 
   // We store the trampoline runner so that header functions that call
   // external asynchronous functions can resume execution in callbacks.
-  global.trampolineRunner = runner;
+  global.resumeTrampoline = runner;
 
   // Before the program finishes, we tell the param store to finish up
   // gracefully (e.g., shutting down a connection to a remote store).

--- a/src/params/store/mongo.js
+++ b/src/params/store/mongo.js
@@ -20,7 +20,7 @@ var _collection = null;
 
 
 function resume(thunk) {
-  global.trampolineRunner(thunk);
+  global.resumeTrampoline(thunk);
 }
 
 function assertInit() {


### PR DESCRIPTION
By reusing the name webppl-editor already uses to expose the runner we avoid breaking webppl code, because we're no longer switching the name of the global variable in which the runner is stored.