### PR TITLE
More flexible parameter initialization.

### DIFF
--- a/docs/optimization/parameters.rst
+++ b/docs/optimization/parameters.rst
@@ -27,12 +27,6 @@ Parameters
       draw from the Gaussian distribution described by the ``mu`` and
       ``sigma`` options.
 
-      Calling ``sample(dist)`` from an initialization function is not
-      supported, and will generate a run time error. Random
-      initialization strategies should instead be implemented in terms
-      of ``dist.sample()``. (Where ``dist`` is a :ref:`distribution
-      object <distributions>`.)
-
    .. describe:: mu
 
       The mean of the Gaussian distribution from which the initial

--- a/docs/optimization/parameters.rst
+++ b/docs/optimization/parameters.rst
@@ -27,6 +27,12 @@ Parameters
       draw from the Gaussian distribution described by the ``mu`` and
       ``sigma`` options.
 
+      Calling ``sample(dist)`` from an initialization function is not
+      supported, and will generate a run time error. Random
+      initialization strategies should instead be implemented in terms
+      of ``dist.sample()``. (Where ``dist`` is a :ref:`distribution
+      object <distributions>`.)
+
    .. describe:: mu
 
       The mean of the Gaussian distribution from which the initial

--- a/docs/optimization/parameters.rst
+++ b/docs/optimization/parameters.rst
@@ -5,9 +5,8 @@ Parameters
 
 .. js:function:: param([options])
 
-   Retrieves the value of a parameter by name. If the parameter does
-   not exist, it is created and initialized with a draw from a
-   Gaussian distribution.
+   Retrieves the value of a parameter by name. The parameter is
+   created if it does not already exist.
 
    The following options are supported:
 
@@ -18,19 +17,29 @@ Parameters
 
       When ``dims`` is omitted, ``param`` returns a scalar.
 
+   .. describe:: init
+
+      A function that computes the initial value of the parameter. The
+      function is passed the dimension of a tensor as its only
+      argument, and should return a tensor of that dimension.
+
+      When ``init`` is omitted, the parameter is initialized with a
+      draw from the Gaussian distribution described by the ``mu`` and
+      ``sigma`` options.
+
    .. describe:: mu
 
       The mean of the Gaussian distribution from which the initial
-      parameter value is drawn.
+      parameter value is drawn when ``init`` is omitted.
 
       Default: ``0``
 
    .. describe:: sigma
 
       The standard deviation of the Gaussian distribution from which
-      the initial parameter value is drawn. Specify a standard
-      deviation of ``0`` to deterministically initialize the parameter
-      to ``mu``.
+      the initial parameter value is drawn when ``init`` is omitted.
+      Specify a standard deviation of ``0`` to deterministically
+      initialize the parameter to ``mu``.
 
       Default: ``0.1``
 
@@ -46,6 +55,7 @@ Parameters
      param({name: 'myparam'})
      param({mu: 0, sigma: 0.01, name: 'myparam'})
      param({dims: [10, 10]})
+     param({dims: [2, 1], init: function(dims) { return ones(dims); }})
 
 .. js:function:: modelParam([options])
 

--- a/src/guide.js
+++ b/src/guide.js
@@ -143,9 +143,10 @@ function makeParam(paramSpec, paramName, baseName, env) {
 }
 
 function registerParam(env, name, dims) {
-  return params.register(env, name, function() {
-    return [new Tensor(dims)];
-  })[0];
+  if (!params.exists(name)) {
+    params.create(name, new Tensor(dims));
+  }
+  return params.fetch(name, env);
 }
 
 // This function generates a description of the guide distribution

--- a/src/inference/forwardSample.js
+++ b/src/inference/forwardSample.js
@@ -60,7 +60,7 @@ module.exports = function(env) {
     factor: function(s, k, a, score) {
       if (!this.sampleGuide) {
         var msg = 'Note that factor, condition and observe statements are ' +
-            'ignored when forward sampling from a model.';
+            'ignored when forward sampling.';
         util.warn(msg, true);
       }
       this.logWeight += ad.value(score);

--- a/src/params/header.js
+++ b/src/params/header.js
@@ -100,8 +100,8 @@ module.exports = function(env) {
       var valDims = ad.value(val).dims;
       if (!_.isEqual(dims, valDims)) {
         var msg = 'The dims specified here (' + JSON.stringify(dims) +
-            ') do not match the dims of the current value (' +
-            JSON.stringify(valDims) + '). The current value may ' +
+            ') do not match the dims of the current parameter value (' +
+            JSON.stringify(valDims) + '). This value may ' +
             'come from an earlier call to param, or from a previous ' +
             'execution when a persistent parameter store is used.';
         throw new Error(msg);

--- a/src/params/header.js
+++ b/src/params/header.js
@@ -44,12 +44,16 @@ function deserializeParams(s, k, a, str) {
   return k(s, serialize.deserializeParams(str));
 }
 
+function defaultInit(mu, sigma) {
+  return function(s, k, a, dims) {
+    return k(s, dists.tensorGaussianSample(mu, sigma, dims));
+  };
+}
+
 module.exports = function(env) {
 
   var dimsForScalarParam = [1];
 
-  // param provides a convenient wrapper around the primitive
-  // params.register.
   var param = function(s, k, a, options) {
     options = util.mergeDefaults(options, {
       mu: 0,
@@ -61,30 +65,31 @@ module.exports = function(env) {
       util.warn('Warning: Parameter created outside of the guide.', true);
     }
 
-    var mu = options.mu;
-    var sigma = options.sigma;
     var dims = options.dims;
     var name = _.has(options, 'name') ? options.name : util.relativizeAddress(env, a);
 
-    var val = params.register(env, name, function() {
-
-      // Initialization.
-
-      var val = new Tensor(dims);
-      if (sigma === 0) {
-        val.fill(mu);
-      } else {
-        for (var i = 0; i < val.length; i++) {
-          val.data[i] = dists.gaussianSample(mu, sigma);
-        }
+    if (params.exists(name)) {
+      return finish(s);
+    } else {
+      var init = _.has(options, 'init') ? options.init : defaultInit(options.mu, options.sigma);
+      if (!_.isFunction(init)) {
+        throw new Error('Expected the init argument to be a function.');
       }
+      return init(s, function(s, initialVal) {
+        params.create(name, initialVal);
+        if (!_.isEqual(dims, initialVal.dims)) {
+          var msg = 'The init function did not return a tensor with the expected shape.';
+          throw new Error(msg);
+        }
+        return finish(s);
+      }, a, dims);
+    }
 
-      // params.register tracks an array of parameters for each
-      // name/address.
-      return [val];
-
-    })[0];
-    return k(s, dims === dimsForScalarParam ? ad.tensor.get(val, 0) : val);
+    function finish(s) {
+      var val = params.fetch(name, env);
+      var valDims = ad.value(val).dims;
+      return k(s, dims === dimsForScalarParam ? ad.tensor.get(val, 0) : val);
+    };
   };
 
   return {

--- a/src/params/header.js
+++ b/src/params/header.js
@@ -88,6 +88,14 @@ module.exports = function(env) {
     function finish(s) {
       var val = params.fetch(name, env);
       var valDims = ad.value(val).dims;
+      if (!_.isEqual(dims, valDims)) {
+        var msg = 'The dims specified here (' + JSON.stringify(dims) +
+            ') do not match the dims of the current value (' +
+            JSON.stringify(valDims) + '). The current value may ' +
+            'come from an earlier call to param, or from a previous ' +
+            'execution when a persistent parameter store is used.';
+        throw new Error(msg);
+      }
       return k(s, dims === dimsForScalarParam ? ad.tensor.get(val, 0) : val);
     };
   };

--- a/src/params/header.js
+++ b/src/params/header.js
@@ -52,6 +52,8 @@ function defaultInit(mu, sigma) {
 
 module.exports = function(env) {
 
+  var applyd = require('../headerUtils')(env).applyd;
+
   var dimsForScalarParam = [1];
 
   var param = function(s, k, a, options) {
@@ -75,14 +77,14 @@ module.exports = function(env) {
       if (!_.isFunction(init)) {
         throw new Error('Expected the init argument to be a function.');
       }
-      return init(s, function(s, initialVal) {
+      return applyd(s, function(s, initialVal) {
         params.create(name, initialVal);
         if (!_.isEqual(dims, initialVal.dims)) {
           var msg = 'The init function did not return a tensor with the expected shape.';
           throw new Error(msg);
         }
         return finish(s);
-      }, a, dims);
+      }, a, init, [dims], 'parameter initialization');
     }
 
     function finish(s) {

--- a/tests/test-data/deterministic/expected/guides.json
+++ b/tests/test-data/deterministic/expected/guides.json
@@ -1,3 +1,3 @@
 {
-  "result": [true, true, true, true, true, true, true]
+  "result": [true, true, true, true, true, true, true, true]
 }

--- a/tests/test-data/deterministic/models/guides.wppl
+++ b/tests/test-data/deterministic/models/guides.wppl
@@ -6,6 +6,7 @@ var numParamsCreatedBy = function(thunk) {
 
 [
   param({mu: 1, sigma: 0}) === 1,
+  param({init: ones}) === 1,
   T.sumreduce(param({dims: [3, 2], mu: 1, sigma: 0})) === 6,
 
   // Check (indirectly) that a guide is automatically generated, by


### PR DESCRIPTION
This extends `param` to take a function specifying how a parameter should be initialized. For example:

```js
param({dims: [2, 1], init: function(dims) { return ones(dims); }})
// => Vector([1,1])
```

The motivation for this change is that it makes it much easier to add alternate weight initialization strategies to webppl-nn.

It was difficult to implement this new version of `param` in terms of the old `register` method as it took a JS function specifying initialization, but here we want to use a webppl function for that. By splitting `register` out into `fetch` and `create`, neither need take a function as an argument, so it's straight forward to work with them from both webppl and JS.

I was nervous about the fact that it's possible to call `sample` from this initialization function. (This seems like a pretty odd thing to do, since the structure of the model would depend on the state of the parameter table.) And this could conceivably happen through a mistaken attempt to specify a random initialization for a parameter. To guard against this, we apply the function in a coroutine where calling `sample` or `factor` generates an error.

<hr/>

This PR also includes a commit that adds some extra run time checks to `param`. Specifically, we now generate an error when the shape of the parameter value we're about to return does not match the `dims` argument given to `param`.

This can happen when a parameter name is reused and the `dims` arguments don't match up. It could also happen across executions if the program code changes when using a persistent parameter store.

The intention is that by checking for this explicitly, we'll get more informative errors than we'd get if we waited until some later part of the program ran into trouble.

It's possible that this will generate an error in a program that would otherwise work, but I think this is a win overall, since it will be useful to know that the dims in the code reflect the actual shape of the parameter.
