### PR TITLE
Include parameter name in warning.

### DIFF
--- a/src/params/header.js
+++ b/src/params/header.js
@@ -64,7 +64,9 @@ module.exports = function(env) {
     });
 
     if (!env.coroutine._guide) {
-      util.warn('Warning: Parameter created outside of the guide.', true);
+      util.warn('Warning: Parameter ' +
+                (_.has(options, 'name') ? '"' + options.name + '" ' : '') +
+                'created outside of the guide.', true);
     }
 
     var dims = options.dims;


### PR DESCRIPTION
This includes the name of the parameter in the warning to aid debugging. I'm only included a name if it is given by the user, auto-generated names seem unlikely to be of much help.