### PR TITLE
Add type information to parameter of Delta dist.

### DIFF
--- a/docs/primitive-distributions.txt
+++ b/docs/primitive-distributions.txt
@@ -44,7 +44,7 @@
 
 .. js:function:: Delta({v: ...})
 
-  * v: support element
+  * v: support element *(any)*
 
   Discrete distribution that assigns probability one to the single element in its support. This is only useful in special circumstances as sampling from ``Delta({v: val})`` can be replaced with ``val`` itself. Furthermore, a ``Delta`` distribution parameterized by a random choice should not be used with MCMC based inference, as doing so produces incorrect results.
 

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -1527,7 +1527,7 @@ var Delta = makeDistributionType({
       'from ``Delta({v: val})`` can be replaced with ``val`` itself. Furthermore, a ``Delta`` ' +
       'distribution parameterized by a random choice should not be used with MCMC based inference, ' +
       'as doing so produces incorrect results.',
-  params: [{name: 'v', desc: 'support element'}],
+  params: [{name: 'v', desc: 'support element', type: types.any}],
   mixins: [finiteSupport],
   sample: function() {
     return ad.value(this.params.v);


### PR DESCRIPTION
Without this, auto mean field for a `Delta` errors out before generating a (vaguely) helpful error message.