### PR TITLE
Gracefully handle failure to auto guide Marginals.

### DIFF
--- a/src/guide.js
+++ b/src/guide.js
@@ -176,7 +176,9 @@ function spec(targetDist) {
     return discreteSpec(targetDist);
   } else if (targetDist instanceof dists.RandomInteger ||
              targetDist instanceof dists.Binomial ||
-             targetDist instanceof dists.MultivariateGaussian) {
+             targetDist instanceof dists.MultivariateGaussian ||
+             targetDist instanceof dists.Marginal ||
+             targetDist instanceof dists.SampleBasedMarginal) {
     throwAutoGuideError(targetDist);
   } else {
     return defaultSpec(targetDist);


### PR DESCRIPTION
After this, we will generate a useful error message when attempting to auto guide a `Marginal`. Fixing this properly would be part of #573.