### PR TITLE
Rename coroutine property

### DIFF
--- a/src/guide.js
+++ b/src/guide.js
@@ -24,7 +24,7 @@ function guideCoroutine(env) {
     sample: sampleNotAllowed,
     factor: factorNotAllowed,
     incrementalize: env.defaultCoroutine.incrementalize,
-    coroutine: env.coroutine,
+    oldCoroutine: env.coroutine,
     // A flag used when creating parameters to check whether we're in
     // a guide thunk. Note that this does the right thing if Infer is
     // used within a guide. This can be checked from a webppl program

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -64,7 +64,8 @@ module.exports = function(env) {
     return {
       sample: notAllowed('sample', name),
       factor: notAllowed('factor', name),
-      incrementalize: env.defaultCoroutine.incrementalize
+      incrementalize: env.defaultCoroutine.incrementalize,
+      oldCoroutine: env.coroutine
     };
   }
 

--- a/src/inference/checkSampleAfterFactor.js
+++ b/src/inference/checkSampleAfterFactor.js
@@ -22,7 +22,7 @@ module.exports = function(env) {
     this.hasFactor = false;
     // at least one sample appears after factor
     this.hasSampleAfterFactor = false;
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -42,7 +42,7 @@ module.exports = function(env) {
 
           // Continuation.
           function() {
-            env.coroutine = this.coroutine;
+            env.coroutine = this.oldCoroutine;
             return this.k(this.s, this.hasSampleAfterFactor);
           }.bind(this));
 

--- a/src/inference/dream/gradients.ad.js
+++ b/src/inference/dream/gradients.ad.js
@@ -20,7 +20,7 @@ module.exports = function(env) {
 
     this.insideMapData = false;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -28,7 +28,7 @@ module.exports = function(env) {
 
     run: function() {
       return this.estimateGradient(function(grad, objVal) {
-        env.coroutine = this.coroutine;
+        env.coroutine = this.oldCoroutine;
         return this.cont(grad, objVal);
       }.bind(this));
     },

--- a/src/inference/dream/sample.js
+++ b/src/inference/dream/sample.js
@@ -35,7 +35,7 @@ module.exports = function(env) {
 
     this.insideMapData = false;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -43,7 +43,7 @@ module.exports = function(env) {
 
     run: function() {
       return this.wpplFn(_.clone(this.s), function(s, val) {
-        env.coroutine = this.coroutine;
+        env.coroutine = this.oldCoroutine;
         return this.k(this.s, this.record);
       }.bind(this), this.a);
     },

--- a/src/inference/elbo.ad.js
+++ b/src/inference/elbo.ad.js
@@ -53,7 +53,7 @@ module.exports = function(env) {
     }
     this.baselineUpdates = {};
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -116,7 +116,7 @@ module.exports = function(env) {
             paramStruct.divEq(grad, this.opts.samples);
             elbo /= this.opts.samples;
             this.updateBaselines();
-            env.coroutine = this.coroutine;
+            env.coroutine = this.oldCoroutine;
             return this.cont(grad, elbo);
           }.bind(this));
 

--- a/src/inference/enumerate.ad.js
+++ b/src/inference/enumerate.ad.js
@@ -46,7 +46,7 @@ module.exports = function(env) {
 
     // Move old coroutine out of the way
     // and install this as the current handler
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -191,7 +191,7 @@ module.exports = function(env) {
         return this.error('All paths explored by Enumerate have probability zero.');
       }
       // Reinstate previous coroutine:
-      env.coroutine = this.coroutine;
+      env.coroutine = this.oldCoroutine;
       // Return from enumeration by calling original continuation with original store:
       return this.k(this.store, this.marginal.toDist());
     }

--- a/src/inference/eubo.ad.js
+++ b/src/inference/eubo.ad.js
@@ -47,7 +47,7 @@ module.exports = function(env) {
     this.guideRequired = true;
     this.isParamBase = true;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -74,7 +74,7 @@ module.exports = function(env) {
           function() {
             paramStruct.divEq(grad, traces.length);
             eubo /= traces.length;
-            env.coroutine = this.coroutine;
+            env.coroutine = this.oldCoroutine;
             return this.cont(grad, eubo);
           }.bind(this),
 

--- a/src/inference/forwardSample.js
+++ b/src/inference/forwardSample.js
@@ -25,7 +25,7 @@ module.exports = function(env) {
     this.score = 0;
     this.logWeight = 0;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -33,7 +33,7 @@ module.exports = function(env) {
 
     run: function() {
       return this.wpplFn(_.clone(this.s), function(s, val) {
-        env.coroutine = this.coroutine;
+        env.coroutine = this.oldCoroutine;
         var ret = {val: val, score: this.score, logWeight: this.logWeight};
         return this.k(this.s, ret);
       }.bind(this), this.a);

--- a/src/inference/hmckernel.js
+++ b/src/inference/hmckernel.js
@@ -37,7 +37,7 @@ module.exports = function(env) {
     this.oldTrace = oldTrace;
     this.a = oldTrace.baseAddress; // Support relative addressing.
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -247,7 +247,7 @@ module.exports = function(env) {
   };
 
   HMCKernel.prototype.continue = function(trace) {
-    env.coroutine = this.coroutine;
+    env.coroutine = this.oldCoroutine;
     return this.cont(trace);
   };
 

--- a/src/inference/initialize.js
+++ b/src/inference/initialize.js
@@ -21,7 +21,7 @@ module.exports = function(env) {
 
     this.ad = options.ad;
     this.failures = 0;
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -62,7 +62,7 @@ module.exports = function(env) {
     if (this.trace.value === env.query) {
       this.trace.value = env.query.getTable();
     }
-    env.coroutine = this.coroutine;
+    env.coroutine = this.oldCoroutine;
     return this.cont(this.trace);
   };
 

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -32,7 +32,7 @@ module.exports = function(env) {
     this.discreteOnly = options.discreteOnly;
     this.adRequired = options.adRequired;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -149,7 +149,7 @@ module.exports = function(env) {
   };
 
   MHKernel.prototype.continue = function(trace) {
-    env.coroutine = this.coroutine;
+    env.coroutine = this.oldCoroutine;
     return this.cont(trace);
   };
 

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -66,7 +66,7 @@ module.exports = function(env) {
     this.k = k;
     this.a = a;
 
-    this.coroutine = env.coroutine;
+    this.oldCoroutine = env.coroutine;
     env.coroutine = this;
   }
 
@@ -339,7 +339,7 @@ module.exports = function(env) {
           if (this.saveTraces) {
             dist.traces = traces;
           }
-          env.coroutine = this.coroutine;
+          env.coroutine = this.oldCoroutine;
           return this.k(this.s, dist);
         }.bind(this),
         this.completeParticles);

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -119,8 +119,8 @@ function fetch(name, env) {
 function findCoroutine(predicate, coroutine) {
   if (predicate(coroutine)) {
     return coroutine;
-  } else if (_.has(coroutine, 'coroutine')) {
-    return findCoroutine(predicate, coroutine.coroutine);
+  } else if (_.has(coroutine, 'oldCoroutine')) {
+    return findCoroutine(predicate, coroutine.oldCoroutine);
   } else {
     return null;
   }


### PR DESCRIPTION
After this change, all coroutines store the coroutine they displace under the `oldCoroutine` property, rather than `coroutine` property, as is commonly the case at present. (As suggested in this [comment](https://github.com/probmods/webppl/pull/801#discussion_r108307774).) I went with `oldCoroutine` rather than `parentCoroutine` because the former is already used by 4 coroutines, so I avoid having to update those.