### PR TITLE
Have rejection and forward sampling take 100 samples by default.

### DIFF
--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -44,7 +44,7 @@ Rejection sampling
 
       The number of samples to take.
 
-      Default: ``1``
+      Default: ``100``
 
    .. describe:: maxScore
 
@@ -327,7 +327,7 @@ Optimization
          The number of samples used to construct the marginal
          distribution.
 
-         Default: ``1``
+         Default: ``100``
 
       .. describe:: onlyMAP
 
@@ -366,7 +366,7 @@ Forward Sampling
 
       The number of samples to take.
 
-      Default: ``1``
+      Default: ``100``
 
    .. describe:: guide
 

--- a/src/inference/forwardSample.js
+++ b/src/inference/forwardSample.js
@@ -81,7 +81,7 @@ module.exports = function(env) {
 
   function ForwardSample(s, k, a, wpplFn, options) {
     var opts = util.mergeDefaults(options, {
-      samples: 1,
+      samples: 100,
       guide: false, // true = sample guide, false = sample target
       onlyMAP: false,
       verbose: false

--- a/src/inference/rejection.js
+++ b/src/inference/rejection.js
@@ -17,7 +17,7 @@ module.exports = function(env) {
   function Rejection(s, k, a, wpplFn, options) {
     util.throwUnlessOpts(options, 'Rejection');
     options = util.mergeDefaults(options, {
-      samples: 1,
+      samples: 100,
       maxScore: 0,
       incremental: false,
       throwOnError: true,


### PR DESCRIPTION
In #709 it was suggested that the number of samples taken when forward sampling should be changed from 1 to 100. This PR does that.

Once forward sampling is updated, rejection would be the only inference algorithm left that doesn't take 100 samples by default, so I updated it as well.
