### PR TITLE
Add error helper.

### DIFF
--- a/docs/functions/other.rst
+++ b/docs/functions/other.rst
@@ -75,3 +75,7 @@ Other
    serializing them with ``JSON.stringify``. This means that memoizing
    a higher-order function will not work as expected, as all functions
    serialize to the same string.
+
+.. js:function:: error(msg)
+
+   Halts execution of the program and prints ``msg`` to the console.

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -447,6 +447,10 @@ var condition = function(bool) {
   factor(bool ? 0 : -Infinity);
 };
 
+var error = function(msg) {
+  util.error(msg);
+};
+
 var MH = function(wpplFn, samples, burn) {
   return MCMC(wpplFn, { samples: samples, burn: burn });
 };
@@ -487,7 +491,7 @@ var DefaultInfer = function(wpplFn, options) {
   } else if (enumResult instanceof Error) {
     console.log(enumResult.message + '..quit enumerate');
   } else {
-    util.fatal('Invalid return value from enumerate');
+    error('Invalid return value from enumerate');
   }
   console.log('Using "rejection"');
   var rejResult = Rejection(wpplFn, {minSampleRate: minSampleRate, throwOnError: false, samples: samples});
@@ -502,7 +506,7 @@ var DefaultInfer = function(wpplFn, options) {
       } else if (smcResult instanceof Error) {
         console.log(smcResult.message + '..quit SMC');
       } else {
-        util.fatal('Invalid return value from SMC');
+        error('Invalid return value from SMC');
       }
     }
     console.log('Using "MCMC"');
@@ -510,14 +514,14 @@ var DefaultInfer = function(wpplFn, options) {
   } else if (dists.isDist(rejResult)) {
     return rejResult;
   } else {
-    util.fatal('Invalid return value from rejection');
+    error('Invalid return value from rejection');
   }
 };
 
 var Infer = function(options, maybeFn) {
   var wpplFn = !util.isObject(options) ? options : maybeFn || options.model;
   if (!_.isFunction(wpplFn)) {
-    util.fatal('Infer: a model was not specified.');
+    error('Infer: a model was not specified.');
   }
 
   // Map from camelCase options to PascalCase coroutine names. Also
@@ -542,7 +546,7 @@ var Infer = function(options, maybeFn) {
     var msg = 'Infer: \'' + methodName +
         '\' is not a valid method. The following methods are available: ' +
         methodNames.join(', ') + '.';
-    util.fatal(msg);
+    error(msg);
   }
   var method = methodMap[methodName];
   return method(wpplFn, _.omit(options, 'method', 'model'));

--- a/src/util.js
+++ b/src/util.js
@@ -286,8 +286,12 @@ function warn(msg, onceOnly) {
   }
 }
 
-function fatal(msg) {
-  throw msg;
+function error(msg) {
+  throw new Error(msg);
+}
+
+function jsthrow(obj) {
+  throw obj;
 }
 
 function jsnew(ctor, arg) {
@@ -374,8 +378,9 @@ module.exports = {
   timeif: timeif,
   warn: warn,
   resetWarnings: resetWarnings,
-  fatal: fatal,
+  error: error,
   jsnew: jsnew,
+  jsthrow: jsthrow,
   isInteger: isInteger,
   isObject: isObject,
   isTensor: isTensor,

--- a/tests/browser/tests.js
+++ b/tests/browser/tests.js
@@ -64,7 +64,7 @@ QUnit.test(
 
 QUnit.test(
     'handling throw string, debug=true',
-    errorTest('util.fatal("fail")', true, function(done, test, error) {
+    errorTest('util.jsthrow("fail")', true, function(done, test, error) {
       test.ok(typeof error === 'string');
       test.ok(error === 'fail');
       done();
@@ -72,7 +72,7 @@ QUnit.test(
 
 QUnit.test(
     'handling throw string, debug=false',
-    errorTest('util.fatal("fail")', false, function(done, test, error) {
+    errorTest('util.jsthrow("fail")', false, function(done, test, error) {
       test.ok(typeof error === 'string');
       test.ok(error === 'fail');
       done();

--- a/tests/test-error-handling.js
+++ b/tests/test-error-handling.js
@@ -17,7 +17,7 @@ function getError(code, test) {
 var tests = [
   // Ensure thrown strings are passed through error handling code.
   function(test) {
-    var error = getError('util.fatal("fail")', test);
+    var error = getError('util.jsthrow("fail")', test);
     test.strictEqual(typeof error, 'string');
     test.ok(error.match(/fail/));
     test.done();

--- a/tests/test-stack-trace.js
+++ b/tests/test-stack-trace.js
@@ -73,17 +73,17 @@ var testDefs = [
   },
 
   { name: 'JS',
-    code: 'util.fatal(util.jsnew(Error))',
+    code: 'util.error("")',
     stack: [
       {file: RegExp(path.join('src', 'util.js') + '$'), webppl: false, name: null},
-      {line: 1, col: 16, file: 'webppl:program', name: 'jsnew'}],
+      {line: 1, col: 5, file: 'webppl:program', name: 'error'}],
     debug: true
   },
   { name: 'JS',
-    code: 'util.fatal(util.jsnew(Error))',
+    code: 'util.error("")',
     stack: [
       {file: RegExp(path.join('src', 'util.js') + '$'), webppl: false, name: null},
-      {line: 1, col: 16, file: 'webppl:program', name: 'jsnew'}],
+      {line: 1, col: 5, file: 'webppl:program', name: 'error'}],
     debug: false
   },
 
@@ -130,7 +130,7 @@ var testDefs = [
   },
 
   { name: 'no webppl entry in stack trace',
-    code: 'util.fatal(util.jsnew(Error))',
+    code: 'util.error("")',
     stack: [{file: RegExp(path.join('src', 'util.js') + '$'), webppl: false, name: null}],
     debug: true,
     limit: 1


### PR DESCRIPTION
The PR replaces the `util.fatal` helper with an `error` helper. This is an improvement since `error` throws an `Error` rather than a string, so we get a mini-stack trace along with the error message. (We didn't have this when `util.fatal` was added.)

I've made `error` a regular WebPPL method and added it to the docs to make it easier to find/use.

Closes #616.