### PR TITLE
Add argument checks to repeat function

### DIFF
--- a/src/header.wppl
+++ b/src/header.wppl
@@ -384,9 +384,9 @@ var groupBy = function(cmp, ar) {
 
 var repeat = function(n, fn) {
   var helper = function(m) {
-    if (m == 0) {
+    if (m === 0) {
       return [];
-    } else if (m == 1) {
+    } else if (m === 1) {
       return [fn()];
     } else {
       var m1 = Math.ceil(m / 2),

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -394,7 +394,12 @@ var repeat = function(n, fn) {
       return helper(m1).concat(helper(m2));
     }
   }
-
+  if (!util.isInteger(n) || n < 0) {
+    error('Expected first argument to be a non-negative integer.');
+  }
+  if (!_.isFunction(fn)) {
+    error('Expected second argument to be a function.');
+  }
   return helper(n);
 }
 


### PR DESCRIPTION
Such checks are particularly worthwhile for`repeat`, as prior to this change, mistakenly transposing the arguments would cause `repeat` to enter an infinite loop.

Partially addresses #380.