### PR TITLE
Remove unhelpful assertion.

### DIFF
--- a/src/inference/elbo.ad.js
+++ b/src/inference/elbo.ad.js
@@ -176,7 +176,6 @@ module.exports = function(env) {
         if (node instanceof SampleNode && node.reparam) {
           return acc + node.multiplier * (node.logq - node.logp);
         } else if (node instanceof SampleNode) {
-          assert.ok(!node.param);
           var weight = naiveLR ? rootNode.weight : node.weight;
           assert.ok(_.isNumber(weight));
           var b = this.computeBaseline(node.address, weight);


### PR DESCRIPTION
`param` is probably a typo for `reparam`. But checking for this is overly cautious here, as this is tested by the `if` clause.