### PR TITLE
Remove linter special casing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,7 @@ module.exports = {
   },
   'extends': 'eslint:recommended',
   'globals': {
-    Float64Array: true,
-    ad: true,
-    T: true
+    Float64Array: true
   },
   'rules': {
     'indent': [

--- a/scripts/adify
+++ b/scripts/adify
@@ -28,7 +28,7 @@ function adRequirePath(srcFilename) {
   var dir = path.dirname(srcFilename);
   var adFileName = path.join(__dirname, '..', 'src', 'ad.js');
   var adPath = path.normalize(path.dirname(path.relative(dir, adFileName)));
-  return adPath + '/' + 'ad.js';
+  return adPath + '/' + 'ad';
 }
 
 // Don't match text editor temporary files. e.g. src/.#dists.ad.js

--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -29,12 +29,15 @@
 
 'use strict';
 
+var ad = require('./ad');
 var Tensor = require('./tensor');
 var _ = require('lodash');
 var util = require('./util');
 var assert = require('assert');
 var inspect = require('util').inspect;
 var types = require('./types');
+
+var T = ad.tensor;
 
 var LOG_PI = 1.1447298858494002;
 var LOG_2PI = 1.8378770664093453;

--- a/src/transforms/adify.js
+++ b/src/transforms/adify.js
@@ -55,7 +55,11 @@ function addAdRequire(ast, adRequirePath) {
   assert.ok(isUseStrictExpr(useStrictNode));
   var requireNode = parse("var ad = require('" + adRequirePath + "');").body[0];
   var rest = body.slice(1);
-  return build.program([useStrictNode, requireNode].concat(rest));
+  // Remove any existing calls to require ad, to avoid duplication.
+  var restFiltered = rest.filter(function(node) {
+    return !_.isEqual(node, requireNode);
+  });
+  return build.program([useStrictNode, requireNode].concat(restFiltered));
 }
 
 function removeUseAdExpressions(ast) {


### PR DESCRIPTION
This is the promised follow-up to #816. It simply adds definitions for `T` and `ad` to `dists.ad.js`. The only complication is a change to the ad transform to ensure that doing this doesn't lead to `ad` been required twice in transformed files.