### PR TITLE
Remove checkpointParams option from Optimize.

### DIFF
--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -56,11 +56,7 @@ module.exports = function(env) {
 
       logProgress: false,
       logProgressFilename: 'optimizeProgress.csv',
-      logProgressThrottle: 200,
-
-      checkpointParams: false,
-      checkpointParamsFilename: 'optimizeParams.json',
-      checkpointParamsThrottle: 10000
+      logProgressThrottle: 200
     });
 
     // Create a (cps) function 'estimator' which computes gradient
@@ -104,15 +100,6 @@ module.exports = function(env) {
       }, options.logProgressThrottle, { trailing: false });
     }
 
-    // For checkpointing params to disk
-    var saveParams, checkpointParams;
-    if (options.checkpointParams) {
-      saveParams = function() {
-        params.save(options.checkpointParamsFilename);
-      };
-      checkpointParams = _.throttle(saveParams, options.checkpointParamsThrottle, { trailing: false });
-    }
-
     // Weight decay.
     var decayWeights = weightDecay.parseOptions(options.weightDecay, options.verbose);
 
@@ -138,9 +125,6 @@ module.exports = function(env) {
             }
             if (options.logProgress) {
               logProgress(i, objective);
-            }
-            if (options.checkpointParams) {
-              checkpointParams();
             }
 
             history.push(objective);
@@ -179,10 +163,6 @@ module.exports = function(env) {
           return options.onFinish(s, function(s) {
             if (options.logProgress) {
               fs.closeSync(logFile);
-            }
-            if (options.checkpointParams) {
-              // Save final params
-              saveParams();
             }
             return k(s);
           }, a, {history: history});


### PR DESCRIPTION
This is a follow up to #822.

>> This raises the question of whether we still need the checkpointParams functionality that's baked into Optimize?

> As far as I can tell, checkpointParams is now obsolete. The only reason I see why someone might still want it is if they wanted to use the Mongo store, but also occasionally save the params to disk. This doesn't seem like a strong-enough reason to keep it. Do you see others?

I suppose one thing you might like to do is read the initial parameters from one file, and then save the updated parameters to some other file. This is a little bit fiddly with the file store since it always reads and writes from the same file, so we'd probably suggest making a copy of the file containing the initial parameters before running the program to achieve something similar. But this doesn't seem like a strong enough reason to keep it around either?
