### PR TITLE
Have categorical helper sample from Categorical rather than Discrete distribution.

### DIFF
--- a/src/dists.ad.js
+++ b/src/dists.ad.js
@@ -1504,7 +1504,6 @@ var Categorical = makeDistributionType({
     {name: 'ps', desc: 'probabilities (can be unnormalized)', type: types.nonNegativeVectorOrRealArray},
     {name: 'vs', desc: 'support', type: types.array(types.any)}],
   wikipedia: true,
-  nohelper: true,
   mixins: [finiteSupport],
   constructor: function() {
     'use ad';

--- a/src/header.wppl
+++ b/src/header.wppl
@@ -7,11 +7,6 @@ var flip = function(p) {
   return sample(Bernoulli(params));
 };
 
-var categorical = function(arg1, arg2) {
-  var params = util.isObject(arg1) ? arg1 : {ps: arg1, vs: arg2};
-  return params.vs[discrete(params.ps)];
-};
-
 var uniformDraw = function(arg) {
   var vs = util.isObject(arg) ? arg.vs : arg;
   if (vs.length == 0) {


### PR DESCRIPTION
After merging this, `categorical` will sample from the expected distribution. That this doesn't happen already is something of a historical oddity. We can mention in the notes for the next release that anyone who wants the previous behaviour can add the code for the old helper to their program.

Closes #397.