### PR TITLE
Only store a single tensor per parameter name

### DIFF
--- a/src/inference/dream/gradients.ad.js
+++ b/src/inference/dream/gradients.ad.js
@@ -45,9 +45,7 @@ module.exports = function(env) {
           objective.backprop();
         }
 
-        var grads = _.mapValues(this.paramsSeen, function(params) {
-          return params.map(ad.derivative);
-        });
+        var grads = _.mapValues(this.paramsSeen, ad.derivative);
 
         return cont(grads, -ad.value(this.logq));
 

--- a/src/inference/elbo.ad.js
+++ b/src/inference/elbo.ad.js
@@ -155,9 +155,7 @@ module.exports = function(env) {
           ret.objective.backprop();
         }
 
-        var grads = _.mapValues(this.paramsSeen, function(params) {
-          return params.map(ad.derivative);
-        });
+        var grads = _.mapValues(this.paramsSeen, ad.derivative);
 
         return cont(grads, ret.elbo);
 

--- a/src/inference/eubo.ad.js
+++ b/src/inference/eubo.ad.js
@@ -101,9 +101,7 @@ module.exports = function(env) {
         var objective = -this.logq;
         objective.backprop();
 
-        var grads = _.mapValues(this.paramsSeen, function(params) {
-          return params.map(ad.derivative);
-        });
+        var grads = _.mapValues(this.paramsSeen, ad.derivative);
 
         var logp = ad.value(trace.score);
         var logq = ad.value(this.logq);

--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -180,21 +180,19 @@ module.exports = function(env) {
 
   function checkGradients(gradObj) {
     // Emit warning when component of gradient is zero.
-    _.each(gradObj, function(grads, name) {
-      _.each(grads, function(g, i) {
-        if (allZero(g)) {
-          logGradWarning(name, i, 'zero');
-        }
-        if (!allFinite(g)) {
-          // Catches NaN, ±Infinity.
-          logGradWarning(name, i, 'not finite');
-        }
-      });
+    _.each(gradObj, function(grad, name) {
+      if (allZero(grad)) {
+        logGradWarning(name, 'zero');
+      }
+      if (!allFinite(grad)) {
+        // Catches NaN, ±Infinity.
+        logGradWarning(name, 'not finite');
+      }
     });
   }
 
-  function logGradWarning(name, i, problem) {
-    util.warn('Gradient for param ' + name + ':' + i + ' is ' + problem + '.', true);
+  function logGradWarning(name, problem) {
+    util.warn('Gradient for param ' + name + ' is ' + problem + '.', true);
   }
 
   return {

--- a/src/params/params.js
+++ b/src/params/params.js
@@ -84,7 +84,7 @@ function create(name, initialVal) {
     throw new Error('Expected an (unlifted) tensor.');
   }
   var paramTable = get();
-  paramTable[name] = [initialVal];
+  paramTable[name] = initialVal;
 }
 
 function fetch(name, env) {
@@ -98,20 +98,20 @@ function fetch(name, env) {
   // If we're outside of optimization, just return the value of the
   // parameter, unlifted.
   if (!paramsSeen) {
-    return paramTable[name][0];
+    return paramTable[name];
   }
 
   // Otherwise we're doing optimization.
   if (_.has(paramsSeen, name)) {
     // Return the same AD graph node that was seen earlier this
     // execution.
-    return paramsSeen[name][0];
+    return paramsSeen[name];
   } else {
     // Fetch the value and lift. Add to paramsSeen so that the
     // coroutine knows to update this parameter.
-    var _param = paramTable[name][0];
+    var _param = paramTable[name];
     var param = ad.lift(_param);
-    paramsSeen[name] = [param];
+    paramsSeen[name] = param;
     return param;
   }
 }

--- a/src/params/serialize.js
+++ b/src/params/serialize.js
@@ -11,20 +11,13 @@ function tensorToObject(tensor) {
 }
 
 function tensorsToObjects(paramObj) {
-  var prms = _.mapValues(paramObj, function(lst) {
-    return lst.map(tensorToObject);
-  });
-  return prms;
+  return _.mapValues(paramObj, tensorToObject);
 }
 
 function objectsToTensors(paramObj) {
-  var prms = {};
-  for (var name in paramObj) {
-    prms[name] = paramObj[name].map(function(tensor) {
-      return new Tensor(tensor.dims).fromFlatArray(tensor.data);
-    });
-  }
-  return prms;
+  return _.mapValues(paramObj, function(tensor) {
+    return new Tensor(tensor.dims).fromFlatArray(tensor.data);
+  });
 }
 
 function serializeParams(paramObj) {

--- a/src/params/store/mongo.js
+++ b/src/params/store/mongo.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash');
-var paramStruct = require('../struct');
 var tensorsToObjects = require('../serialize').tensorsToObjects;
 var objectsToTensors = require('../serialize').objectsToTensors;
 

--- a/src/params/struct.js
+++ b/src/params/struct.js
@@ -1,60 +1,44 @@
 // Operations on the data structure that holds guide parameters or
 // gradients.
 
-// The data structure looks like this:
-
-// {
-//   name1: [tensor11, tensor12, ...],
-//   name2: [tensor21, tensor22, ...],
-//   ...
-// }
+// The data structure is a dictionary mapping parameter names (string)
+// to parameter values (tensor).
 
 'use strict';
 
 var assert = require('assert');
 var _ = require('lodash');
 
-
 function addEq(g, h) {
   // In-place addition.
-  _.each(h, function(hs, a) {
+  _.each(h, function(val, a) {
     if (!_.has(g, a)) {
-      g[a] = hs;
+      g[a] = val;
     } else {
-      var gs = g[a];
-      assert.strictEqual(gs.length, hs.length);
-      for (var i = 0; i < gs.length; i++) {
-        gs[i].addeq(hs[i]);
-      }
+      g[a].addeq(val);
     }
   });
 }
 
 function mulEq(g, s) {
   // In-place multiplication by a scalar.
-  _.each(g, function(gs) {
-    for (var i = 0; i < gs.length; i++) {
-      gs[i].muleq(s);
-    }
+  _.each(g, function(val) {
+    val.muleq(s);
   });
 }
 
 function divEq(g, s) {
   // In-place division by a scalar.
-  _.each(g, function(gs) {
-    for (var i = 0; i < gs.length; i++) {
-      gs[i].diveq(s);
-    }
+  _.each(g, function(val) {
+    val.diveq(s);
   });
 }
 
 function norm(g) {
   // Compute the L2 norm.
   var normsq = 0;
-  _.each(g, function(gs) {
-    _.each(gs, function(g) {
-      normsq += g.mul(g).sumreduce();
-    });
+  _.each(g, function(val) {
+    normsq += val.mul(val).sumreduce();
   });
   return Math.sqrt(normsq);
 }
@@ -67,8 +51,8 @@ function clip(g, threshold, normOfG) {
 }
 
 function deepCopy(g) {
-  return _.mapValues(g, function(arr) {
-    return arr.map(function(tensor) { return tensor.clone(); });
+  return _.mapValues(g, function(val) {
+    return val.clone();
   });
 }
 
@@ -76,7 +60,7 @@ function deepCopy(g) {
 // h. Assumes that every key in h is also a key in g.
 function select(g, h) {
   return _.mapValues(h, function(unused, key) {
-    return g[key].map(function(tensor) { return tensor.clone(); });
+    return g[key].clone();
   });
 }
 

--- a/src/params/struct.js
+++ b/src/params/struct.js
@@ -66,13 +66,6 @@ function clip(g, threshold, normOfG) {
   }
 }
 
-function copy(g) {
-  // Shallow copy.
-  return _.mapValues(g, function(arr) {
-    return arr.slice();
-  });
-}
-
 function deepCopy(g) {
   return _.mapValues(g, function(arr) {
     return arr.map(function(tensor) { return tensor.clone(); });
@@ -93,7 +86,6 @@ module.exports = {
   divEq: divEq,
   norm: norm,
   clip: clip,
-  copy: copy,
   deepCopy: deepCopy,
   select: select
 };


### PR DESCRIPTION
Before this change, each parameter name had associated with it an array of tensor valued parameters. Previously, this was used as the basis for supporting the use of adnn networks in WebPPL programs. However, this [isn't something we currently support](https://github.com/probmods/webppl/issues/663#issuecomment-272113800), so these arrays are redundant.

The only potential problem I see with this is that after the change, it won't be possible to load parameters persisted to file/mongo using the old format. I'm not sure this is worth worrying about though?
