### PR TITLE
Initialize store before running compiled code.

### DIFF
--- a/webppl
+++ b/webppl
@@ -76,7 +76,7 @@ function compile(code, packages, verbose, debug, programFile, outputFile) {
     'var __runner__ = util.trampolineRunners.cli();',
     topK.toString() + ';',
     'var main = ' + compiledBody + '\n',
-    "main({})(__runner__)({}, topK, '');"
+    "webppl.runEvaled(main, __runner__, {}, {}, topK, '');"
   ]);
 
   // Write Javascript code to file


### PR DESCRIPTION
This fixes #812 by ensuring the parameter store is initialized before running code compiled with `--compile`. Note that at present, compiled code will always use the default parameter store (i.e. the memory based store).

Fixes #812.
