### PR TITLE
Make `cache` callable as `dp.cache`

### DIFF
--- a/docs/functions/other.rst
+++ b/docs/functions/other.rst
@@ -81,6 +81,25 @@ Other
       var y = { b: 3, c: 4 };
       extend(x, y);  // => { a: 1, b: 3, c: 4 }
 
+.. js:function:: cache(fn, maxSize)
+
+   Returns a memoized version of ``fn``. The memoized function is
+   backed by a cache that is shared across all executions/possible
+   worlds.
+
+   ``cache`` is provided as a means of avoiding the repeated
+   computation of a *deterministic* function. The use of ``cache``
+   with a *stochastic* function is unlikely to be appropriate. For
+   stochastic memoization see :js:func:`mem`.
+
+   When ``maxSize`` is specified the memoized function is backed by a
+   LRU cache of size ``maxSize``. The cache has unbounded size when
+   ``maxSize`` is omitted.
+
+   ``cache`` can be used to memoize mutually recursive functions,
+   though for technical reasons it must currently be called as
+   ``dp.cache`` for this to work.
+
 .. js:function:: mem(fn)
 
    Returns a memoized version of ``fn``. The memoized function is

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -14,12 +14,14 @@ module.exports = function(env) {
     return k(s, console.log(ad.valueRec(x)));
   }
 
+  var dp = {};
+
   // Caching for a wppl function f.
   //
   // Caution: if f isn't deterministic weird stuff can happen, since
   // caching is across all uses of f, even in different execution
   // paths.
-  function cache(s, k, a, f, maxSize) {
+  dp.cache = function(f, maxSize) {
     var c = LRU(maxSize);
     var cf = function(s, k, a) {
       var args = Array.prototype.slice.call(arguments, 3);
@@ -47,7 +49,11 @@ module.exports = function(env) {
         return f.apply(this, [s, newk, a].concat(args));
       }
     };
-    return k(s, cf);
+    return cf;
+  };
+
+  function cache(s, k, a, f, maxSize) {
+    return k(s, dp.cache(f, maxSize));
   }
 
   function apply(s, k, a, wpplFn, args) {
@@ -207,6 +213,7 @@ module.exports = function(env) {
   return {
     display: display,
     cache: cache,
+    dp: dp,
     apply: apply,
     applyd: applyd,
     _Fn: _Fn,

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -49,6 +49,9 @@ module.exports = function(env) {
         return f.apply(this, [s, newk, a].concat(args));
       }
     };
+    // Make the cache publicly available to facilitate checking the
+    // complexity of algorithms.
+    cf.cache = c;
     return cf;
   };
 

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -17,7 +17,7 @@ module.exports = function(env) {
   // Caching for a wppl function f.
   //
   // Caution: if f isn't deterministic weird stuff can happen, since
-  // caching is across all uses of f, even in different execuation
+  // caching is across all uses of f, even in different execution
   // paths.
   function cache(s, k, a, f, maxSize) {
     var c = LRU(maxSize);

--- a/tests/test-data/deterministic/expected/cache.json
+++ b/tests/test-data/deterministic/expected/cache.json
@@ -1,3 +1,3 @@
 {
-  "result": true
+  "result": [true, true, true, true, true]
 }

--- a/tests/test-data/deterministic/models/cache.wppl
+++ b/tests/test-data/deterministic/models/cache.wppl
@@ -1,2 +1,17 @@
-var id = cache(function(x) { return x; });
-id(Infinity) === Infinity && id(-Infinity) === -Infinity;
+var id = cache(function(x) { globalStore.x += 1; return x; });
+// Test mutual recursion between cached functions.
+var odd = dp.cache(function(n) { return n <= 0 ? false : even(n - 1); });
+var even = dp.cache(function(n) { return n <= 0 ? true : odd(n - 1); });
+
+[
+  (function() {
+    globalStore.x = 0;
+    id(0);
+    id(0);
+    return globalStore.x === 1;
+  })(),
+  id(Infinity) === Infinity,
+  id(-Infinity) === -Infinity,
+  odd(3),
+  even(4)
+];


### PR DESCRIPTION
Closes #850.