### PR TITLE
Support early exit from `Optimize`.

### DIFF
--- a/docs/optimization/optimize.rst
+++ b/docs/optimization/optimize.rst
@@ -75,6 +75,9 @@ Optimize
         var callback = function(index, value) { /* ... */ };
         Optimize({model: model, steps: 100, onStep: callback});
 
+      If this function returns ``true``, ``Optimize`` will return
+      immediately, skipping any remaining optimization steps.
+
    .. describe:: verbose
 
       Default: ``true``

--- a/src/inference/optimize.js
+++ b/src/inference/optimize.js
@@ -103,9 +103,18 @@ module.exports = function(env) {
     var decayWeights = weightDecay.parseOptions(options.weightDecay, options.verbose);
 
     var onStep = function(i, objective, cont) {
-      return applyd(s, function(s, val) {
-        return cont();
+      return applyd(s, function(s, exitFlag) {
+        return exitFlag ? finish() : cont();
       }, a, options.onStep, [i, objective], 'callback');
+    };
+
+    var finish = function() {
+      return options.onFinish(s, function(s) {
+        if (options.logProgress) {
+          fs.closeSync(logFile);
+        }
+        return k(s);
+      }, a, {history: history});
     };
 
     // Main loop.
@@ -158,14 +167,7 @@ module.exports = function(env) {
         },
 
         // Loop continuation.
-        function() {
-          return options.onFinish(s, function(s) {
-            if (options.logProgress) {
-              fs.closeSync(logFile);
-            }
-            return k(s);
-          }, a, {history: history});
-        });
+        finish);
 
   }
 


### PR DESCRIPTION
With this, returning `true` (or any other truthy value) from the `onStep` callback stops optimization. 

The return value of `onStep` was ignored previously, so I expect most existing uses of `onStep` to return implicitly return `undefined`, in which case this change won't alter the behaviour of existing code.