### PR TITLE
Mention default guides in the docs

### DIFF
--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -40,3 +40,35 @@ computation. Instead, the :ref:`global store <globalstore>` should be
 used to pass results to subsequent guide computations. This
 arrangement encourages a programming style in which there is
 separation between the model and the guide.
+
+.. _default_guides:
+
+Default Guide Distributions
+---------------------------
+
+Both :ref:`optimization <optimization>` and :ref:`forward sampling
+<forward_sampling>` from the guide require that all :ref:`random
+choices <sample>` in the model have a corresponding :ref:`guide
+distribution <guides>`. So, for convenience, these methods
+automatically use an appropriate *default guide distribution* at any
+random choice in the model for which a guide distribution is not
+specified explicitly.
+
+Default guide distributions can also be used with :ref:`SMC <smc>`.
+See the documentation for the ``importance`` option for details.
+
+The default guide distribution used at a particular random choice:
+
+* Is independent of all other guide distributions in the program.
+* Has its type determined by the type of the distribution specified in
+  the model for the random choice.
+* Has each of its continuous parameters hooked up to an optimizable
+  :ref:`parameter <parameters>`. These parameters are not shared with
+  any other guide distributions in the program.
+
+For example, the default guide distribution for a ``Bernoulli`` random
+choice could be written explicitly as::
+
+  var x = sample(Bernoulli({p: 0.5}), {guide: function() {
+    return Bernoulli({p: Math.sigmoid(param())});
+  }});

--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -239,6 +239,7 @@ Incremental MH
          :param any value: Value to be added to query.
          :returns: undefined
 
+.. _smc:
 
 SMC
 ---
@@ -293,9 +294,9 @@ SMC
 
          * ``'autoGuide'``: When a random choice has a :ref:`guide
            distribution <guides>` specified, use that as the
-           importance distribution. For all other random choices,
-           automatically generate a mean-field guide and use that as
-           the importance distribution.
+           importance distribution. For all other random choices, use
+           a :ref:`default guide distribution <default_guides>` as the
+           importance distribution.
 
            Default: ``'default'``
 
@@ -372,8 +373,12 @@ Forward Sampling
 
    .. describe:: guide
 
-      When ``true``, sample random choices from the guide using the
-      current global parameters. Otherwise, sample from the model.
+      When ``true``, sample random choices from the guide. A
+      :ref:`default guide distribution <default_guides>` is used for
+      random choices that do not have a guide distribution specified
+      explicitly.
+
+      When ``false``, sample from the model.
 
       Default: ``false``
 

--- a/docs/optimization/optimize.rst
+++ b/docs/optimization/optimize.rst
@@ -11,6 +11,10 @@ Optimize
    Optimizes the parameters of the guide program specified by the
    ``model`` option.
 
+   A :ref:`default guide distribution <default_guides>` is used for
+   random choices that do not have a guide distribution specified
+   explicitly.
+
    The following options are supported:
 
    .. describe:: model

--- a/src/guide.js
+++ b/src/guide.js
@@ -94,7 +94,7 @@ function getDist(maybeThunk, noAutoGuide, targetDist, env, s, a, k) {
 
 function independent(targetDist, sampleAddress, env) {
 
-  util.warn('Automatically generating guide for one or more choices.', true);
+  util.warn('Using the default guide distribution for one or more choices.', true);
 
   // Include the distribution name in the guide parameter name to
   // avoid collisions when the distribution type changes between


### PR DESCRIPTION
Partially addresses #584.

At some point we might also what to document how the guide/model types/families line up. But that is probably best done by extending the existing distribution meta data, which in turn suggests combining the [information](https://github.com/probmods/webppl/blob/177b1508dd56a3a705024cea3e4453ee4dfb511e/src/guide.js#L241) used to select guides with the distributions themselves. That might not happen for a while, but it still seems worth having these docs in the meantime.