### PR TITLE
Throw error when attempting to `cache` on AD nodes.

### DIFF
--- a/docs/functions/other.rst
+++ b/docs/functions/other.rst
@@ -100,6 +100,11 @@ Other
    though for technical reasons it must currently be called as
    ``dp.cache`` for this to work.
 
+   ``cache`` does not support caching functions of scalar/tensor
+   arguments when performing inference with gradient based algorithms.
+   (e.g. :ref:`HMC <hmc>`, :ref:`ELBO <elbo>`.) Attempting to do so
+   will produce an error.
+
 .. js:function:: mem(fn)
 
    Returns a memoized version of ``fn``. The memoized function is

--- a/docs/inference/methods.rst
+++ b/docs/inference/methods.rst
@@ -136,6 +136,8 @@ Example usage::
 
     Infer({method: 'MCMC', kernel: 'MH', model: model});
 
+.. _hmc:
+
 .. describe:: HMC
 
    Implements Hamiltonian Monte Carlo. [neal11]_

--- a/src/headerUtils.js
+++ b/src/headerUtils.js
@@ -25,6 +25,12 @@ module.exports = function(env) {
     var c = LRU(maxSize);
     var cf = function(s, k, a) {
       var args = Array.prototype.slice.call(arguments, 3);
+
+      if (_.some(args, ad.isLifted)) {
+        throw new Error('Cannot cache functions of scalar/tensor arguments ' +
+                        'when performing automatic differentiation.');
+      }
+
       var stringedArgs = serialize(args);
       if (c.has(stringedArgs)) {
         return k(s, c.get(stringedArgs));


### PR DESCRIPTION
As discussed in #420, `cache` doesn't work as expected when the function to memoize takes an AD node as argument. This change adds a check for this situation, and throws an error when it happens.