### PR TITLE
Warn when impossible observations are made.

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -114,7 +114,12 @@ module.exports = function(env) {
         var factorK = function(s) {
           return k(s, val);
         };
-        return env.factor(s, factorK, a, dist.score(val));
+        var score = dist.score(val);
+        if (ad.value(score) === -Infinity) {
+          util.warn('Warning: One or more values given to observe have a score of ' +
+                    '-Infinity under the ' + dist.meta.name + ' distribution.', true);
+        }
+        return env.factor(s, factorK, a, score);
       } else {
         return env.sample(s, k, a, dist, options);
       }


### PR DESCRIPTION
For example, this:

```js
observe(Uniform({a: 0, b: 1}), 2);
```

... now generates the following warning:

```
Warning: One or more values given to observe have a
score of -Infinity under the Uniform distribution.
```

One thing that's not so great about this is that it may not be clear where in the program this is coming from. The easiest way I can think of to address this would be to turn the warning into an error so that we get a "stack trace", but I'm not sure that this would always be desirable?

Note that any coroutine supplying its own `observe` implementation will have to generate a similar warning if appropriate. Currently only dream does this, and I don't think it requires this warning.

Closes #621.