### PR TITLE
Pull more fns into numeric module.

### DIFF
--- a/src/aggregation/ScoreAggregator.ad.js
+++ b/src/aggregation/ScoreAggregator.ad.js
@@ -5,18 +5,7 @@ var assert = require('assert');
 var _ = require('lodash');
 var dists = require('../dists');
 var util = require('../util');
-
-function logaddexp(a, b) {
-  if (a === -Infinity) {
-    return b;
-  } else if (b === -Infinity) {
-    return a;
-  } else if (a > b) {
-    return Math.log(1 + Math.exp(b - a)) + a;
-  } else {
-    return Math.log(1 + Math.exp(a - b)) + b;
-  }
-}
+var numeric = require('../math/numeric');
 
 var ScoreAggregator = function() {
   this.dist = {};
@@ -34,13 +23,13 @@ ScoreAggregator.prototype.add = function(value, score) {
   if (this.dist[key] === undefined) {
     this.dist[key] = { score: -Infinity, val: value };
   }
-  this.dist[key].score = logaddexp(this.dist[key].score, score);
+  this.dist[key].score = numeric.logaddexp(this.dist[key].score, score);
 };
 
 function normalize(dist) {
   // Note, this also maps dist from log space into probability space.
   var logNorm = _.reduce(dist, function(acc, obj) {
-    return logaddexp(acc, obj.score);
+    return numeric.logaddexp(acc, obj.score);
   }, -Infinity);
   return _.mapValues(dist, function(obj) {
     return { val: obj.val, prob: Math.exp(obj.score - logNorm) };

--- a/src/dists/discrete.ad.js
+++ b/src/dists/discrete.ad.js
@@ -9,7 +9,7 @@ var numeric = require('../math/numeric');
 var T = ad.tensor;
 
 function sample(theta) {
-  var thetaSum = util.sum(theta);
+  var thetaSum = numeric._sum(theta);
   var x = util.random() * thetaSum;
   var k = theta.length;
   var probAccum = 0;

--- a/src/dists/kde.ad.js
+++ b/src/dists/kde.ad.js
@@ -6,6 +6,7 @@ var types = require('../types');
 var util = require('../util');
 var Tensor = require('../tensor');
 var stats = require('../math/statistics');
+var numeric = require('../math/numeric');
 var gaussian = require('./gaussian');
 var diagCovGaussian = require('./diagCovGaussian');
 
@@ -102,7 +103,7 @@ var KDE = base.makeDistributionType({
     var kernel = this.kernel;
     return data.reduce(
       function(acc, x) {
-        return util.logaddexp(acc, kernel.score(x, width, val));
+        return numeric.logaddexp(acc, kernel.score(x, width, val));
       },
       -Infinity) - Math.log(n);
   }

--- a/src/dists/multinomial.ad.js
+++ b/src/dists/multinomial.ad.js
@@ -16,7 +16,7 @@ function zeros(n) {
 }
 
 function sample(theta, n) {
-  // var thetaSum = util.sum(theta);
+  // var thetaSum = numeric._sum(theta);
   var a = zeros(theta.length);
   for (var i = 0; i < n; i++) {
     a[discrete.sample(theta)]++;

--- a/src/inference/asyncpf.js
+++ b/src/inference/asyncpf.js
@@ -8,6 +8,7 @@
 
 var _ = require('lodash');
 var util = require('../util');
+var numeric = require('../math/numeric');
 var CountAggregator = require('../aggregation/CountAggregator');
 
 module.exports = function(env) {
@@ -114,8 +115,8 @@ module.exports = function(env) {
       var currWeight = this.activeParticle.weight;
       var denom = lk.length + currMultiplicity; // k - 1 + Ckn
       var prevWBar = lk[lk.length - 1].wbar;
-      var wbar = -Math.log(denom) + util.logsumexp([Math.log(lk.length) + prevWBar,
-                                                    Math.log(currMultiplicity) + currWeight]);
+      var wbar = -Math.log(denom) + numeric._logsumexp([Math.log(lk.length) + prevWBar,
+                                                        Math.log(currMultiplicity) + currWeight]);
       if (wbar > 0) throw new Error('Positive weight!!'); // sanity check
       var logRatio = currWeight - wbar;
       var numChildrenAndWeight = [];

--- a/src/inference/forwardSample.js
+++ b/src/inference/forwardSample.js
@@ -5,6 +5,7 @@
 
 var _ = require('lodash');
 var util = require('../util');
+var numeric = require('../math/numeric');
 var CountAggregator = require('../aggregation/CountAggregator');
 var ad = require('../ad');
 var guide = require('../guide');
@@ -104,7 +105,7 @@ module.exports = function(env) {
         function() {
           var dist = hist.toDist();
           if (!opts.guide) {
-            dist.normalizationConstant = util.logsumexp(logWeights) - Math.log(opts.samples);
+            dist.normalizationConstant = numeric._logsumexp(logWeights) - Math.log(opts.samples);
           }
           return k(s, dist);
         }

--- a/src/inference/mhkernel.js
+++ b/src/inference/mhkernel.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var assert = require('assert');
 var util = require('../util');
+var numeric = require('../math/numeric');
 var ad = require('../ad');
 
 module.exports = function(env) {
@@ -215,7 +216,7 @@ module.exports = function(env) {
     var score = ad.value(proposalDist.score(regenChoice.val));
 
     // Rest of the trace.
-    score += util.sum(toTrace.choices.slice(this.regenFrom + 1).map(function(choice) {
+    score += numeric._sum(toTrace.choices.slice(this.regenFrom + 1).map(function(choice) {
       return this.reused.hasOwnProperty(choice.address) ? 0 : ad.value(choice.dist.score(choice.val));
     }, this));
 

--- a/src/inference/smc.js
+++ b/src/inference/smc.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var util = require('../util');
+var numeric = require('../math/numeric');
 var discrete = require('../dists/discrete');
 var Trace = require('../trace');
 
@@ -154,7 +155,7 @@ module.exports = function(env) {
     }
     // Residual resampling following Liu 2008; p. 72, section 3.4.4
     var m = particles.length;
-    var logW = util.logsumexp(_.map(particles, 'logWeight'));
+    var logW = numeric._logsumexp(_.map(particles, 'logWeight'));
     var logAvgW = logW - Math.log(m);
     if (logAvgW === -Infinity) {
       // do not return, execution continues

--- a/src/math/numeric.ad.js
+++ b/src/math/numeric.ad.js
@@ -1,13 +1,38 @@
 'use strict';
 
+var _ = require('lodash');
 var ad = require('../ad');
 
 var LOG_PI = 1.1447298858494002;
 var LOG_2PI = 1.8378770664093453;
 
+// By convention, non-adified versions of functions are prefixed with
+// an underscore.
+
 function sum(xs) {
   'use ad';
   return xs.reduce(function(a, b) { return a + b; }, 0);
+}
+
+function _sum(xs) {
+  if (xs.length === 0) {
+    return 0.0;
+  } else {
+    var total = _.reduce(xs,
+        function(a, b) {
+          return a + b;
+        });
+    return total;
+  }
+}
+
+function product(xs) {
+  'use ad';
+  var result = 1;
+  for (var i = 0, n = xs.length; i < n; i++) {
+    result *= xs[i];
+  }
+  return result;
 }
 
 function fact(x) {
@@ -60,12 +85,24 @@ function logaddexp(a, b) {
   }
 }
 
+function _logsumexp(a) {
+  var m = Math.max.apply(null, a);
+  var sum = 0;
+  for (var i = 0; i < a.length; ++i) {
+    sum += (a[i] === -Infinity ? 0 : Math.exp(a[i] - m));
+  }
+  return m + Math.log(sum);
+}
+
 module.exports = {
   LOG_PI: LOG_PI,
   LOG_2PI: LOG_2PI,
   sum: sum,
+  _sum: _sum,
+  product: product,
   fact: fact,
   lnfact: lnfact,
   squishToProbSimplex: squishToProbSimplex,
-  logaddexp: logaddexp
+  logaddexp: logaddexp,
+  _logsumexp: _logsumexp
 };

--- a/src/math/numeric.ad.js
+++ b/src/math/numeric.ad.js
@@ -47,11 +47,25 @@ function squishToProbSimplex(x) {
   return ad.tensor.softmax(u);
 }
 
+function logaddexp(a, b) {
+  'use ad';
+  if (a === -Infinity) {
+    return b;
+  } else if (b === -Infinity) {
+    return a;
+  } else if (a > b) {
+    return Math.log(1 + Math.exp(b - a)) + a;
+  } else {
+    return Math.log(1 + Math.exp(a - b)) + b;
+  }
+}
+
 module.exports = {
   LOG_PI: LOG_PI,
   LOG_2PI: LOG_2PI,
   sum: sum,
   fact: fact,
   lnfact: lnfact,
-  squishToProbSimplex: squishToProbSimplex
+  squishToProbSimplex: squishToProbSimplex,
+  logaddexp: logaddexp
 };

--- a/src/transforms/adify.js
+++ b/src/transforms/adify.js
@@ -8,7 +8,6 @@ var generate = require('escodegen').generate;
 var build = require('ast-types').builders;
 var _ = require('lodash');
 var ad = require('./ad').ad;
-var util = require('../util');
 
 function isMarkedForGlobalTransform(ast) {
   assert.ok(ast.type === 'Program');

--- a/src/types.js
+++ b/src/types.js
@@ -8,6 +8,7 @@
 
 var _ = require('lodash');
 var util = require('./util');
+var numeric = require('./math/numeric');
 var interval = require('./math/interval');
 
 var isInterval = interval.isInterval;
@@ -136,7 +137,7 @@ var probabilityArray = function() {
     name: 'probabilityArray',
     desc: 'real array with elements that sum to one',
     check: function(val) {
-      return baseType.check(val) && Math.abs(1 - util.sum(val)) < tol;
+      return baseType.check(val) && Math.abs(1 - numeric._sum(val)) < tol;
     }
   };
 };

--- a/src/util.js
+++ b/src/util.js
@@ -112,18 +112,6 @@ function logsumexp(a) {
   return m + Math.log(sum);
 }
 
-function logaddexp(a, b) {
-  if (a === -Infinity) {
-    return b;
-  } else if (b === -Infinity) {
-    return a;
-  } else if (a > b) {
-    return Math.log(1 + Math.exp(b - a)) + a;
-  } else {
-    return Math.log(1 + Math.exp(a - b)) + b;
-  }
-}
-
 var deleteIndex = function(arr, i) {
   return arr.slice(0, i).concat(arr.slice(i + 1))
 }
@@ -397,7 +385,6 @@ module.exports = {
   histsApproximatelyEqual: histsApproximatelyEqual,
   gensym: gensym,
   logsumexp: logsumexp,
-  logaddexp: logaddexp,
   deleteIndex: deleteIndex,
   makeGensym: makeGensym,
   prettyJSON: prettyJSON,

--- a/src/util.js
+++ b/src/util.js
@@ -5,8 +5,12 @@ var assert = require('assert');
 var seedrandom = require('seedrandom');
 var ad = require('./ad');
 var Tensor = require('./tensor');
+var numeric = require('./math/numeric');
 
 var rng = Math.random;
+
+// Re-export sum from this module, as expected by webppl-viz.
+var sum = numeric._sum;
 
 var trampolineRunners = {
   web: function(yieldEvery) {
@@ -81,35 +85,6 @@ function prettyJSON(obj) {
 
 function asArray(arg) {
   return arg ? [].concat(arg) : [];
-}
-
-function sum(xs) {
-  if (xs.length === 0) {
-    return 0.0;
-  } else {
-    var total = _.reduce(xs,
-        function(a, b) {
-          return a + b;
-        });
-    return total;
-  }
-}
-
-function product(xs) {
-  var result = 1;
-  for (var i = 0, n = xs.length; i < n; i++) {
-    result *= xs[i];
-  }
-  return result;
-}
-
-function logsumexp(a) {
-  var m = Math.max.apply(null, a);
-  var sum = 0;
-  for (var i = 0; i < a.length; ++i) {
-    sum += (a[i] === -Infinity ? 0 : Math.exp(a[i] - m));
-  }
-  return m + Math.log(sum);
 }
 
 var deleteIndex = function(arr, i) {
@@ -384,7 +359,6 @@ module.exports = {
   histStd: histStd,
   histsApproximatelyEqual: histsApproximatelyEqual,
   gensym: gensym,
-  logsumexp: logsumexp,
   deleteIndex: deleteIndex,
   makeGensym: makeGensym,
   prettyJSON: prettyJSON,
@@ -392,7 +366,6 @@ module.exports = {
   mergeDefaults: mergeDefaults,
   getValAndOpts: getValAndOpts,
   sum: sum,
-  product: product,
   asArray: asArray,
   serialize: serialize,
   deserialize: deserialize,

--- a/tests/test-data/sampler/beta.js
+++ b/tests/test-data/sampler/beta.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var assert = require('assert');
 var beta = require('../../../src/dists/beta');
-var util = require('../../../src/util');
+var numeric = require('../../../src/math/numeric');
 var statistics = require('../../../src/math/statistics');
 
 var ln = Math.log,
@@ -40,7 +40,7 @@ module.exports = {
     var a = params[0];
     var b = params[1];
     // https://en.wikipedia.org/wiki/Beta_distribution#Higher_moments
-    return util.product(_.range(0, n - 1).map(function(k) { return (a + k) / (a + b + k) }))
+    return numeric.product(_.range(0, n - 1).map(function(k) { return (a + k) / (a + b + k) }))
   },
   // mostly HT https://en.wikipedia.org/wiki/Gamma_distribution
   populationStatisticFunctions: {

--- a/tests/test-data/sampler/gamma.js
+++ b/tests/test-data/sampler/gamma.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var assert = require('assert');
 var gamma = require('../../../src/dists/gamma');
-var util = require('../../../src/util');
+var numeric = require('../../../src/math/numeric');
 var statistics = require('../../../src/math/statistics');
 
 var ln = Math.log,
@@ -39,7 +39,7 @@ module.exports = {
     // HT http://ocw.mit.edu/courses/mathematics/
     // 18-443-statistics-for-applications-fall-2006/lecture-notes/lecture6.pdf
     // (but NB: they use shape, rate whereas we have shape, scale)
-    return util.product(_.range(0, n - 1).map(function(k) { return shape + k })) * pow(scale, n)
+    return numeric.product(_.range(0, n - 1).map(function(k) { return shape + k })) * pow(scale, n)
   },
   // mostly HT https://en.wikipedia.org/wiki/Gamma_distribution
   populationStatisticFunctions: {

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -20,11 +20,11 @@ module.exports = {
       var xs = [-Infinity, -100, -30, -1, 0, 1, 10];
       xs.forEach(
           function(x) {
-            testAlmostEqual(test, x, util.logsumexp([x]), epsilon);
+            testAlmostEqual(test, x, numeric._logsumexp([x]), epsilon);
             xs.forEach(
                 function(y) {
                   var targetVal = Math.log(Math.exp(x) + Math.exp(y));
-                  var actualVal = util.logsumexp([x, y]);
+                  var actualVal = numeric._logsumexp([x, y]);
                   testAlmostEqual(test, targetVal, actualVal, epsilon);
                 });
           });

--- a/tests/test-util.js
+++ b/tests/test-util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var util = require('../src/util');
+var numeric = require('../src/math/numeric');
 
 function testAlmostEqual(test, x, y, epsilon) {
   if (x === y) {
@@ -34,23 +35,23 @@ module.exports = {
 
   testLogAddExp: {
     test1: function(test) {
-      testAlmostEqual(test, Math.exp(util.logaddexp(Math.log(1), Math.log(2))), 3, 1e-6);
+      testAlmostEqual(test, Math.exp(numeric.logaddexp(Math.log(1), Math.log(2))), 3, 1e-6);
       test.done();
     },
     test2: function(test) {
-      testAlmostEqual(test, Math.exp(util.logaddexp(Math.log(2), Math.log(1))), 3, 1e-6);
+      testAlmostEqual(test, Math.exp(numeric.logaddexp(Math.log(2), Math.log(1))), 3, 1e-6);
       test.done();
     },
     test3: function(test) {
-      testAlmostEqual(test, Math.exp(util.logaddexp(-Infinity, Math.log(1))), 1, 1e-6);
+      testAlmostEqual(test, Math.exp(numeric.logaddexp(-Infinity, Math.log(1))), 1, 1e-6);
       test.done();
     },
     test4: function(test) {
-      testAlmostEqual(test, Math.exp(util.logaddexp(Math.log(1), -Infinity)), 1, 1e-6);
+      testAlmostEqual(test, Math.exp(numeric.logaddexp(Math.log(1), -Infinity)), 1, 1e-6);
       test.done();
     },
     test5: function(test) {
-      testAlmostEqual(test, Math.exp(util.logaddexp(-Infinity, -Infinity)), 0, 1e-6);
+      testAlmostEqual(test, Math.exp(numeric.logaddexp(-Infinity, -Infinity)), 0, 1e-6);
       test.done();
     }
   },


### PR DESCRIPTION
This moves the `logaddexp`, `sum`, `product` functions into the `numeric` module. (This is the follow-up PR I mentioned [here](https://github.com/probmods/webppl/pull/872#issue-242067653)).

This makes things a little tidier than they were. For example, previously we had both `util.sum` (not differentiable) and `dists.sum` (differentiable) in the code base, but it wasn't clear why.  Both are now in `numeric`, and the non differentiable version is called `_sum`.

I considered having only the differentiable version, but AD adds quite a bit of overhead, so I think it's worth have the non-AD version around for cases where we know AD is not required. (IIRC I saw about 20x slow down when summing over an array of length 1e6 with AD.)

`webppl-viz` calls `util.sum`, so to maintain compatibility I'm continuing to make that available for now. We might want to discuss other approaches.

I can't find any other uses of `util.sum` and friends outside of WebPPL. It's possible that users call this directly in their programs, but perhaps unlikely, since we have a (top-level) `sum` function?