### PR TITLE
Add mixture distribution primitive

### DIFF
--- a/docs/primitive-distributions.txt
+++ b/docs/primitive-distributions.txt
@@ -135,6 +135,13 @@
 
   `Wikipedia entry <https://en.wikipedia.org/wiki/Logit-normal_distribution>`__
 
+.. js:function:: Mixture({dists: ..., ps: ...})
+
+  * dists: array of component distributions
+  * ps: component probabilities (can be unnormalized) *(vector or real array [0, Infinity))*
+
+  A finite mixture of continuous distributions. The component distributions should all share a common support.
+
 .. js:function:: Multinomial({ps: ..., n: ...})
 
   * ps: probabilities *(real array with elements that sum to one)*

--- a/docs/primitive-distributions.txt
+++ b/docs/primitive-distributions.txt
@@ -140,7 +140,7 @@
   * dists: array of component distributions
   * ps: component probabilities (can be unnormalized) *(vector or real array [0, Infinity))*
 
-  A finite mixture of continuous distributions. The component distributions should all share a common support.
+  A finite mixture of distributions. The component distributions should be either all discrete or all continuous. All continuous distributions should share a common support.
 
 .. js:function:: Multinomial({ps: ..., n: ...})
 

--- a/src/dists/base.ad.js
+++ b/src/dists/base.ad.js
@@ -175,20 +175,27 @@ function makeDistributionType(options) {
   // Note that Chrome uses the name of this local variable in the
   // output of `console.log` when it's called on a distribution that
   // uses the default constructor.
-  var dist = function(params) {
+
+  // The option to skip parameter checks is only used internally. It
+  // makes it possible to avoid performing checks multiple times when
+  // one distribution uses another distribution internally.
+
+  var dist = function(params, skipParamChecks) {
     params = params || {};
-    parameterNames.forEach(function(p, i) {
-      if (params.hasOwnProperty(p)) {
-        var type = parameterTypes[i];
-        if (type && !type.check(ad.valueRec(params[p]))) {
-          throw new Error('Parameter \"' + p + '\" should be of type "' + type.desc + '".');
+    if (!skipParamChecks) {
+      parameterNames.forEach(function(p, i) {
+        if (params.hasOwnProperty(p)) {
+          var type = parameterTypes[i];
+          if (type && !type.check(ad.valueRec(params[p]))) {
+            throw new Error('Parameter \"' + p + '\" should be of type "' + type.desc + '".');
+          }
+        } else {
+          if (!parameterOptionalFlags[i]) {
+            throw new Error('Parameter \"' + p + '\" missing from ' + this.meta.name + ' distribution.');
+          }
         }
-      } else {
-        if (!parameterOptionalFlags[i]) {
-          throw new Error('Parameter \"' + p + '\" missing from ' + this.meta.name + ' distribution.');
-        }
-      }
-    }, this);
+      }, this);
+    }
     this.params = params;
     if (extraConstructorFn !== undefined) {
       extraConstructorFn.call(this);

--- a/src/dists/index.ad.js
+++ b/src/dists/index.ad.js
@@ -25,6 +25,7 @@ var distributions = _.chain(
     ['LogisticNormal', require('./logisticNormal')],
     ['LogitNormal', require('./logitNormal')],
     ['Marginal', require('./marginal')],
+    ['Mixture', require('./mixture')],
     ['Multinomial', require('./multinomial')],
     ['MultivariateBernoulli', require('./multivariateBernoulli')],
     ['MultivariateGaussian', require('./multivariateGaussian')],

--- a/src/dists/mixture.ad.js
+++ b/src/dists/mixture.ad.js
@@ -1,0 +1,86 @@
+'use strict';
+
+var _ = require('lodash');
+var ad = require('../ad');
+var base = require('./base');
+var types = require('../types');
+var numeric = require('../math/numeric');
+var Discrete = require('./discrete').Discrete;
+
+function isContinuousDist(d) {
+  return base.isDist(d) && d.isContinuous;
+}
+
+function supportEq(s1, s2) {
+  return s1 === s2 ||
+    (s1 !== undefined &&
+     s2 !== undefined &&
+     s1.lower === s2.lower &&
+     s1.upper === s2.upper);
+}
+
+var Mixture = base.makeDistributionType({
+  name: 'Mixture',
+  desc: 'A finite mixture of continuous distributions. ' +
+    'The component distributions should all share a common support.',
+  params: [
+    {
+      name: 'dists',
+      desc: 'array of component distributions'
+    },
+    {
+      name: 'ps',
+      desc: 'component probabilities (can be unnormalized)',
+      type: types.nonNegativeVectorOrRealArray
+    }
+  ],
+  wikipedia: false,
+  mixins: [base.continuousSupport],
+  constructor: function() {
+    var dists = this.params.dists;
+    var ps = this.params.ps;
+
+    if (!_.isArray(dists)) {
+      throw new Error('Parameter dists should be an array.');
+    }
+
+    if (dists.length !== ad.value(ps).length) {
+      throw new Error('Parameters ps and dists should have the same length.');
+    }
+
+    if (dists.length === 0) {
+      throw new Error('Parameters ps and dists should be non-empty.');
+    }
+
+    if (!_.every(dists, isContinuousDist)) {
+      throw new Error('Parameter dists should be an array of continuous distributions.');
+    }
+
+    var support = dists[0].support && dists[0].support();
+    for (var i = 1; i < dists.length; i++) {
+      if (!supportEq(support, dists[i].support && dists[i].support())) {
+        throw new Error('All distributions should have the same support.');
+      }
+    }
+    this.support = support && _.constant(support);
+
+    this.indicatorDist = new Discrete({ps: ps});
+  },
+  sample: function() {
+    var i = this.indicatorDist.sample();
+    return this.params.dists[i].sample();
+  },
+  score: function(val) {
+    'use ad';
+    var dists = this.params.dists;
+    var s = -Infinity;
+    for (var i = 0; i < dists.length; i++) {
+      s = numeric.logaddexp(s, this.indicatorDist.score(i) + dists[i].score(val));
+    }
+    return s;
+  }
+});
+
+module.exports = {
+  Mixture: Mixture
+};

--- a/src/dists/mixture.ad.js
+++ b/src/dists/mixture.ad.js
@@ -64,7 +64,7 @@ var Mixture = base.makeDistributionType({
     }
     this.support = support && _.constant(support);
 
-    this.indicatorDist = new Discrete({ps: ps});
+    this.indicatorDist = new Discrete({ps: ps}, true);
   },
   sample: function() {
     var i = this.indicatorDist.sample();

--- a/src/guide.js
+++ b/src/guide.js
@@ -174,6 +174,7 @@ function spec(targetDist) {
   } else if (targetDist instanceof dists.Binomial) {
     return discreteSpec(targetDist.params.n + 1);
   } else if (targetDist instanceof dists.MultivariateGaussian ||
+             targetDist instanceof dists.Mixture ||
              targetDist instanceof dists.Marginal ||
              targetDist instanceof dists.SampleBasedMarginal) {
     throwAutoGuideError(targetDist);

--- a/tests/test-data/deterministic/expected/mixture.json
+++ b/tests/test-data/deterministic/expected/mixture.json
@@ -1,0 +1,3 @@
+{
+  "result": true
+}

--- a/tests/test-data/deterministic/models/mixture.wppl
+++ b/tests/test-data/deterministic/models/mixture.wppl
@@ -1,0 +1,56 @@
+var approxEq = function(x, y) {
+  return Math.abs(x - y) < 1e-8;
+};
+
+var g1 = Gaussian({mu: ad.lift(0), sigma: 1});
+var g2 = Gaussian({mu: 1, sigma: 2});
+var g3 = DiagCovGaussian({mu: ad.lift(Vector([0])), sigma: Vector([1])});
+var g4 = DiagCovGaussian({mu: Vector([1]), sigma: Vector([2])});
+
+var cases = [
+
+  // Scoring
+
+  (function() {
+    var x = 3;
+    var m = Mixture({ps: [ad.lift(0.4), 0.6], dists: [g1, g2]});
+    var trueScore = Math.log(0.4 * Math.exp(g1.score(x)) + 0.6 * Math.exp(g2.score(x)));
+    return approxEq(m.score(x), trueScore);
+  })(),
+
+  (function() {
+    var x = 3;
+    var m = Mixture({ps: ad.lift(Vector([0.4, 0.6])), dists: [g1, g2]});
+    var trueScore = Math.log(0.4 * Math.exp(g1.score(x)) + 0.6 * Math.exp(g2.score(x)));
+    return approxEq(m.score(x), trueScore);
+  })(),
+
+  (function() {
+    var x = 3;
+    var m = Mixture({ps: [ad.lift(0.4), 0.6], dists: [g3, g4]});
+    var trueScore = Math.log(0.4 * Math.exp(g1.score(x)) + 0.6 * Math.exp(g2.score(x)));
+    return approxEq(m.score(Vector([x])), trueScore);
+  })(),
+
+  // Sampling
+
+  (function() {
+    var m = Mixture({ps: [1, 0], dists: [Gaussian({mu: -3, sigma: 1e-12}), g1]});
+    return approxEq(sample(m), -3);
+  })(),
+
+  // Support
+
+  (function() {
+    var m = Mixture({ps: [0.5, 0.5], dists: [g1, g2]});
+    return m.support === undefined;
+  })(),
+
+  (function() {
+    var m = Mixture({ps: [0.5, 0.5], dists: [Uniform({a: 0, b: 1}), Uniform({a: 0, b: 1})]});
+    return m.support().lower === 0 && m.support().upper === 1;
+  })()
+
+];
+
+all(idF, cases);

--- a/tests/test-data/deterministic/models/mixture.wppl
+++ b/tests/test-data/deterministic/models/mixture.wppl
@@ -7,6 +7,14 @@ var g2 = Gaussian({mu: 1, sigma: 2});
 var g3 = DiagCovGaussian({mu: ad.lift(Vector([0])), sigma: Vector([1])});
 var g4 = DiagCovGaussian({mu: Vector([1]), sigma: Vector([2])});
 
+var discreteMixture = Mixture({
+  ps: [0.4,0.6],
+  dists: [
+    Categorical({vs: [[0], [1]]}),
+    Categorical({vs: [[1], [2], [3]]})
+  ]
+});
+
 var cases = [
 
   // Scoring
@@ -32,11 +40,24 @@ var cases = [
     return approxEq(m.score(Vector([x])), trueScore);
   })(),
 
+  (function() {
+    return approxEq(discreteMixture.score([0]), Math.log(0.2)) &&
+      approxEq(discreteMixture.score([1]), Math.log(0.4)) &&
+      approxEq(discreteMixture.score([2]), Math.log(0.2)) &&
+      approxEq(discreteMixture.score([3]), Math.log(0.2)) &&
+      discreteMixture.score([4]) === -Infinity;
+  })(),
+
   // Sampling
 
   (function() {
     var m = Mixture({ps: [1, 0], dists: [Gaussian({mu: -3, sigma: 1e-12}), g1]});
     return approxEq(sample(m), -3);
+  })(),
+
+  (function() {
+    var m = Mixture({ps: [1, 0], dists: [Delta({v: 'a'}), Bernoulli({p: 0.5})]});
+    return sample(m) === 'a';
   })(),
 
   // Support
@@ -49,6 +70,21 @@ var cases = [
   (function() {
     var m = Mixture({ps: [0.5, 0.5], dists: [Uniform({a: 0, b: 1}), Uniform({a: 0, b: 1})]});
     return m.support().lower === 0 && m.support().upper === 1;
+  })(),
+
+  (function() {
+    return _.isEqual(discreteMixture.support(), [[0], [1], [2], [3]]);
+  })(),
+
+  // `isContinuous` flag
+
+  (function() {
+    var m = Mixture({ps: [0.5, 0.5], dists: [Uniform({a: 0, b: 1}), Uniform({a: 0, b: 1})]});
+    return m.isContinuous;
+  })(),
+
+  (function() {
+    return !discreteMixture.isContinuous;
   })()
 
 ];


### PR DESCRIPTION
First attempt at a `Mixture` distribution primitive. Allows things like:

```js
var g1 = Gaussian({mu: 2, sigma: 1});
var g2 = Gaussian({mu: -2, sigma: 0.5});
var mix = Mixture({dists: [g1, g2], ps: [0.3, 0.7]});
var x = sample(mix);
```

The scorer is differentiable assuming the scorers of the components are, so this will work with gradient based algos. (Addressing the 2 use cases mentioned by @dritchie in #713.)

Closes #713.