### PR TITLE
Clean-up language docs, add to TOC.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ WebPPL Documentation
    :maxdepth: 2
 
    gettingstarted
+   language
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
My primary motivation for this is to have *something* on docs.webppl.org about which function calls are interpreted as JS function calls, and a hint about the seemingly common gotcha of trying to call `parseInt` and the like.