### PR TITLE
Ensure forward slash is used when requiring ad on Windows.

### DIFF
--- a/scripts/adify
+++ b/scripts/adify
@@ -28,7 +28,9 @@ function adRequirePath(srcFilename) {
   var dir = path.dirname(srcFilename);
   var adFileName = path.join(__dirname, '..', 'src', 'ad.js');
   var adPath = path.normalize(path.dirname(path.relative(dir, adFileName)));
-  return adPath + '/' + 'ad';
+  // Replace platform dependent path separator with '/' which is used
+  // with `require` across all platforms.
+  return adPath.split(path.sep).join('/') + '/' + 'ad';
 }
 
 // Don't match text editor temporary files. e.g. src/.#dists.ad.js


### PR DESCRIPTION
Closes #874.