### PR TITLE
Fix #891

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+bundle/
+docs/_build
+*.ad.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
 
 install:
   - npm install
+  - if [ $TRAVIS_NODE_VERSION = 4 ]; then npm run-script prepare; fi
+  - if [ $TRAVIS_NODE_VERSION = 5 ]; then npm run-script prepare; fi
+  - if [ $TRAVIS_NODE_VERSION = 6 ]; then npm run-script prepare; fi
   - npm install -g nodeunit grunt-cli
   - if [ $TASK = travis-phantomjs ]; then npm install -g browserify uglify-js; fi
 

--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -7,6 +7,7 @@ Installation from GitHub
 
     git clone https://github.com/probmods/webppl.git
     cd webppl
+    npm --version # ensure >= 4.0.0 (required to run build scripts)
     npm install
     npm install -g nodeunit grunt-cli
 

--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -1,7 +1,7 @@
 Installation from GitHub
 ========================
 
-.. highlight:: none
+.. highlight:: bash
 
 ::
 

--- a/docs/development/npm.rst
+++ b/docs/development/npm.rst
@@ -29,4 +29,5 @@ Updating the npm package
     git push origin dev
     git push origin master
     git push origin v0.0.1  # use version printed by "npm version" command above
+    npm --version # ensure >= 4.0.0 (required to run build scripts)
     npm publish

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "test": "nodeunit tests",
-    "postinstall": "node scripts/adify && node scripts/distHeader"
+    "prepare": "node scripts/adify && node scripts/distHeader"
   },
   "bugs": {
     "url": "https://github.com/probmods/webppl/issues"


### PR DESCRIPTION
This is a proposed fix for issue #891.

The problem: At present we perform some code transformations at npm package install time, i.e. when a user issues `npm install -g webppl`. Issue #891 is about a problem some users run into where the transformations fail because npm runs our script with insufficient privileges. This PR aims to fix that problem by having the transformations happen at package creation time.

For the most part, making this work is just a case of updating `package.json` to change when the script runs. (Using the [`prepare`](https://docs.npmjs.com/misc/scripts#prepublish-and-prepare) rather than `postinstall` hook.) We also need to add an [`.npmignore`](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package) file to ensure that the files generated by the transform are included to the package. (Without this npm decides what to include based on `.gitignore`, and we don't include the transformed files in the git repo.) I've also added `*.ad.js` to `.npmignore`, since I can't think of a reason why the *untransformed* source files need to go into the package.

As far as I can tell, this approach will work. Here's what I did in an attempt to confirm this:

* Tested creating the package using `npm pack` from within my local clone of this branch. (This creates the package tarball without publishing it.) The transforms run as expected, and the transformed files are included in the resulting tarball. This requires npm v4.0.0 or later.

* Installed the resulting package with something like `npm install -g webppl-0.9.11.tgz `. The package was installed successfully, and (as expected) the transform does not run. Once installed, I changed into the installed package's directory and confirmed that the transformed files are present. I also ran `npm run-script test`, and all tests passed. Since no scripts are now run during this phase, I don't think there are any additional constraints on supported npm versions for end users.

* Used npm to install this branch directly from git using `npm install -g git+https://github.com/null-a/webppl.git#fix-891`. Again I confirmed the transformed files appear on disk and that the tests pass. (With this method there is no indication in npm's output that the transforms run.) It appears that this requires npm v5.0.0 or later. (Based on my understanding of these [release notes](https://github.com/npm/npm/releases/tag/v5.0.0).)

* Tested running `npm install` from within my local clone of the git repo. (As done during development.) In this case the transform script *does* run, which is the desired behaviour. This requires npm 4.0.0 or later.

I've performed the above with node/npm pairs v6/v4.0.0 and v8/v6.0.0. (Aside: I think node >= 7 is required for npm 6.0.0)

(cc @stuhlmueller)

*Edited to add more info about npm version requirements, and addition testing performed.*