### PR TITLE
Minor tweaks related to publishing npm package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 bundle/
 docs/_build
 *.ad.js
+webppl-*.tgz

--- a/docs/development/npm.rst
+++ b/docs/development/npm.rst
@@ -30,4 +30,4 @@ Updating the npm package
     git push origin master
     git push origin v0.0.1  # use version printed by "npm version" command above
     npm --version # ensure >= 4.0.0 (required to run build scripts)
-    npm publish
+    npm publish --unsafe-perm # flag prevents scripts failing when npm is run as root


### PR DESCRIPTION
The change to `.npmignore` is to prevent the tarball created by `npm pack` from been added to the package itself when `npm pack` is run multiple times. This hasn't bit us yet, and it would only make the package bigger than it could otherwise be, but it seems worth guarding against, just in case.