### PR TITLE
Add inference callbacks to support streaming samples to disk.

### DIFF
--- a/src/header.wppl
+++ b/src/header.wppl
@@ -468,8 +468,8 @@ var SampleGuide = function(wpplFn, options) {
 };
 
 var OptimizeThenSample = function(wpplFn, options) {
-  Optimize(wpplFn, _.omit(options, 'samples', 'onlyMAP'));
-  var opts = _.pick(options, 'samples', 'onlyMAP', 'verbose');
+  Optimize(wpplFn, _.omit(options, 'samples', 'onlyMAP', 'callbacks'));
+  var opts = _.pick(options, 'samples', 'onlyMAP', 'callbacks', 'verbose');
   return SampleGuide(wpplFn, opts);
 };
 

--- a/src/inference/callbacks.js
+++ b/src/inference/callbacks.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var _ = require('lodash');
+
+// `prepare` takes an array of callback objects that looks like this:
+
+// [
+//   {setup: function(arg) {}, iteration: function(arg) {}},
+//   ...
+// ]
+
+// And returns a single object that is operationally equivalent to
+// this:
+
+// {
+//   setup: function(arg) { _.invokeMap(callbacks, 'setup', arg); },
+//   iteration: function(arg) { _.invokeMap(callbacks, 'iteration', arg); },
+//   ...
+// }
+
+// The actual implementation aims to improve on this by avoiding
+// traversing the array of callback objects each time an event is
+// trigger when we know ahead of time that none of the objects include
+// handlers for the event.
+
+var prepareOne = function(name, callbacks) {
+  var fns = [];
+  callbacks.forEach(function(obj) {
+    if (_.has(obj, name)) {
+      fns.push(obj[name]);
+    }
+  });
+  if (_.isEmpty(fns)) {
+    return _.noop;
+  } else {
+    return function(arg) {
+      fns.forEach(function(f) { f(arg); });
+    };
+  }
+};
+
+var names = ['setup', 'initialize', 'iteration', 'finish'];
+
+var prepare = function(callbacks) {
+  return _.fromPairs(names.map(function(name) {
+    return [name, prepareOne(name, callbacks)];
+  }));
+};
+
+module.exports = {
+  prepare: prepare
+};

--- a/src/inference/callbacks.js
+++ b/src/inference/callbacks.js
@@ -39,7 +39,7 @@ var prepareOne = function(name, callbacks) {
   }
 };
 
-var names = ['setup', 'initialize', 'iteration', 'finish'];
+var names = ['setup', 'initialize', 'iteration', 'sample', 'finish'];
 
 var prepare = function(callbacks) {
   return _.fromPairs(names.map(function(name) {

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -1,0 +1,22 @@
+{
+  "result": [
+    {
+      "setup": 3,
+      "initialize": true,
+      "numIters": 3,
+      "finish": true
+    },
+    {
+      "setup": 5,
+      "initialize": true,
+      "numIters": 5,
+      "finish": true
+    },
+    {
+      "setup": 8,
+      "initialize": true,
+      "numIters": 8,
+      "finish": true
+    }
+  ]
+}

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -5,7 +5,7 @@
       "initialize": true,
       "numIters": 3,
       "finish": true,
-      "numSamples": 0
+      "numSamples": 3
 
     },
     {
@@ -13,7 +13,7 @@
       "initialize": true,
       "numIters": 5,
       "finish": true,
-      "numSamples": 0
+      "numSamples": 3
 
     },
     {
@@ -21,7 +21,7 @@
       "initialize": true,
       "numIters": 8,
       "finish": true,
-      "numSamples": 0
+      "numSamples": 3
     }
   ]
 }

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -22,6 +22,13 @@
       "numIters": 8,
       "finish": true,
       "numSamples": 3
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 3
     }
   ]
 }

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -36,6 +36,20 @@
       "numIters": 0,
       "finish": true,
       "numSamples": 3
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 3
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 6
     }
   ]
 }

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -4,19 +4,24 @@
       "setup": 3,
       "initialize": true,
       "numIters": 3,
-      "finish": true
+      "finish": true,
+      "numSamples": 0
+
     },
     {
       "setup": 5,
       "initialize": true,
       "numIters": 5,
-      "finish": true
+      "finish": true,
+      "numSamples": 0
+
     },
     {
       "setup": 8,
       "initialize": true,
       "numIters": 8,
-      "finish": true
+      "finish": true,
+      "numSamples": 0
     }
   ]
 }

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -29,6 +29,13 @@
       "numIters": 0,
       "finish": true,
       "numSamples": 3
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 3
     }
   ]
 }

--- a/tests/test-data/deterministic/expected/callbacks.json
+++ b/tests/test-data/deterministic/expected/callbacks.json
@@ -50,6 +50,20 @@
       "numIters": 0,
       "finish": true,
       "numSamples": 6
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 3
+    },
+    {
+      "setup": false,
+      "initialize": false,
+      "numIters": 0,
+      "finish": true,
+      "numSamples": 3
     }
   ]
 }

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -55,4 +55,5 @@ var runTest = function(inferOpts) {
   runTest({method: 'MCMC', samples: 3}),
   runTest({method: 'MCMC', samples: 3, burn: 2}),
   runTest({method: 'MCMC', samples: 3, burn: 2, lag: 1}),
+  runTest({method: 'rejection', samples: 3}),
 ];

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -57,4 +57,6 @@ var runTest = function(inferOpts) {
   runTest({method: 'MCMC', samples: 3, burn: 2, lag: 1}),
   runTest({method: 'rejection', samples: 3}),
   runTest({method: 'incrementalMH', samples: 3}),
+  runTest({method: 'SMC', particles: 3}),
+  runTest({method: 'SMC', particles: 3, rejuvSteps: 2}),
 ];

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -1,5 +1,5 @@
 var make_callback = function() {
-  var output = { setup: [], initialize: [], iteration: [], finish: [] };
+  var output = { setup: [], initialize: [], iteration: [], sample: [], finish: [] };
   var cb = {
     // Inference should pass a single argument, the number of
     // iterations that will be performed. We push this onto the
@@ -12,6 +12,7 @@ var make_callback = function() {
     // arguments. Here we ignore any such arguments, and push true
     // onto the array each time we're called.
     iteration: _.ary(_.bindKey(output.iteration, 'push', true), 0),
+    sample: _.bindKey(output.sample, 'push'),
     // Finished is called with zero arguments once inference is
     // complete. We push true onto the array when called.
     finish: _.ary(_.bindKey(output.finish, 'push', true), 0),
@@ -31,6 +32,13 @@ var summarize_output = function(output) {
     // `numIters` is the number of times the iteration callback was
     // called.
     numIters: output.iteration.length,
+    // All inference algorithms are expected to provide an object with
+    // at least a value property, though they may return an object
+    // with additional properties. `numSamples` will be the number of
+    // times the sample callback was invoked, unless it was called one
+    // or more times with an object without `value` property, in which
+    // case it will be false.
+    numSamples: all(function(s) { return _.has(s, 'value'); }, output.sample) && output.sample.length,
     // `finish` will be true if the finish callback was called, false
     // otherwise.
     finish: output.finish.length === 1 && output.finish[0]

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -59,4 +59,6 @@ var runTest = function(inferOpts) {
   runTest({method: 'incrementalMH', samples: 3}),
   runTest({method: 'SMC', particles: 3}),
   runTest({method: 'SMC', particles: 3, rejuvSteps: 2}),
+  runTest({method: 'optimize', samples: 3}),
+  runTest({method: 'forward', samples: 3}),
 ];

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -1,0 +1,50 @@
+var make_callback = function() {
+  var output = { setup: [], initialize: [], iteration: [], finish: [] };
+  var cb = {
+    // Inference should pass a single argument, the number of
+    // iterations that will be performed. We push this onto the
+    // output.
+    setup: _.bindKey(output.setup, 'push'),
+    // MCMC calls this after collecting the initial trace. This pushes
+    // true onto the output array when called.
+    initialize: _.ary(_.bindKey(output.initialize, 'push', true), 0),
+    // Inference calls this after each iteration, passing zero or more
+    // arguments. Here we ignore any such arguments, and push true
+    // onto the array each time we're called.
+    iteration: _.ary(_.bindKey(output.iteration, 'push', true), 0),
+    // Finished is called with zero arguments once inference is
+    // complete. We push true onto the array when called.
+    finish: _.ary(_.bindKey(output.finish, 'push', true), 0),
+    output: output
+  };
+  return cb;
+};
+
+var summarize_output = function(output) {
+  return {
+    // This `setup` property will be the expected number of
+    // iterations, false otherwise.
+    setup: output.setup.length === 1 && output.setup[0],
+    // `initialize` will be true if the initialize callback was
+    // called, false otherwise.
+    initialize: output.initialize.length === 1 && output.initialize[0],
+    // `numIters` is the number of times the iteration callback was
+    // called.
+    numIters: output.iteration.length,
+    // `finish` will be true if the finish callback was called, false
+    // otherwise.
+    finish: output.finish.length === 1 && output.finish[0]
+  };
+};
+
+var runTest = function(inferOpts) {
+  var cb = make_callback();
+  Infer(_.merge({model: constF('retval'), callbacks: [cb]}, inferOpts));
+  return summarize_output(cb.output);
+};
+
+[
+  runTest({method: 'MCMC', samples: 3}),
+  runTest({method: 'MCMC', samples: 3, burn: 2}),
+  runTest({method: 'MCMC', samples: 3, burn: 2, lag: 1}),
+];

--- a/tests/test-data/deterministic/models/callbacks.wppl
+++ b/tests/test-data/deterministic/models/callbacks.wppl
@@ -56,4 +56,5 @@ var runTest = function(inferOpts) {
   runTest({method: 'MCMC', samples: 3, burn: 2}),
   runTest({method: 'MCMC', samples: 3, burn: 2, lag: 1}),
   runTest({method: 'rejection', samples: 3}),
+  runTest({method: 'incrementalMH', samples: 3}),
 ];


### PR DESCRIPTION
@mhtess has long wanted to be able to stream samples to disk rather than accumulate them in memory. This PR aims to make that possible by adding a new callback to our sampling based inference methods that is called whenever a sample is collected. With this, it's possible to implement the desired functionality as [a simple package](https://github.com/null-a/webppl-sample-writer/tree/use-sample-callback). This package would be used in conjunction with the `onlyMAP` option so that WebPPL doesn't keep all collected samples in memory.

**Other approaches**

Obviously this isn't the only way to go about this. A more direct approach would be to have inference take a new parameter, `saveSamples` say, that accepts a filename and arranges for the samples to be written to disk. The actual work could happen in `SampleBasedMarginal`. While this would remove the need for the additional package, I'm inclined to favor the callback based approach because it's simpler on the WebPPL side, and this functionality could plausibly be used for other things. Let me know if you feel otherwise.

**Performance**

I've included in this PR a commit which reduces the overhead associated with the previous callback implementation. Previously invoking a hook would always involve traversing a (tiny) array, even when there was no work to do, whereas now we only make a call to `_.noop` in such cases. This should ensure that the overhead from adding these new callbacks is negligible.

**Next steps**

As a first step it would be good to get feedback on the general approach. If we stick with this, and we decide that we'd like it to be part of the public interface, I can consider trying to write some documentation as a follow-up PR.